### PR TITLE
Update Durable Functions templates to v1.3.0-rc

### DIFF
--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -1844,7 +1844,7 @@
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.3.0-rc"
       },
       "settings": [
         {
@@ -1878,7 +1878,7 @@
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.3.0-rc"
       },
       "settings": [
         {
@@ -1912,7 +1912,7 @@
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.3.0-rc"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.3.0-rc"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.3.0-rc"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
@@ -34,7 +34,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3",
+        "version": "1.3.0-rc",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.3.0-rc"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.3.0-rc"
     }
   ]
 }


### PR DESCRIPTION
We just released a new version of the Durable Functions nuget package to nuget.org: https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask. This PR is to update the templates to reference the new package.

This is my first PR to the templates repo, so let me know if I'm doing it wrong. :)