### PR TITLE
Update Durable Functions templates to install v1.4.0 (GA build)

### DIFF
--- a/FallBackFolderBuild/extensions.json
+++ b/FallBackFolderBuild/extensions.json
@@ -17,7 +17,7 @@
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.4.0"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.EventGrid",

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -1844,7 +1844,7 @@
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.4.0"
       },
       "settings": [
         {
@@ -1878,7 +1878,7 @@
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.4.0"
       },
       "settings": [
         {
@@ -1912,7 +1912,7 @@
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3"
+        "version": "1.4.0"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.4.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.4.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
@@ -34,7 +34,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.2.2-beta3",
+        "version": "1.4.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.4.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.2.2-beta3"
+      "version": "1.4.0"
     }
   ]
 }


### PR DESCRIPTION
The portal templates are currently very outdated, and we want people to start using the latest GA version starting at Build.