### PR TITLE
added default proxies.json

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
@@ -15,5 +15,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="proxies.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Functions.Templates/ProjectTemplate/CSharp/proxies.json
+++ b/Functions.Templates/ProjectTemplate/CSharp/proxies.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/proxies",
+  "proxies": {}
+}

--- a/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
@@ -15,5 +15,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="proxies.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Functions.Templates/ProjectTemplate/FSharp/proxies.json
+++ b/Functions.Templates/ProjectTemplate/FSharp/proxies.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/proxies",
+  "proxies": {}
+}

--- a/Functions.Templates/ProjectTemplates.nuspec
+++ b/Functions.Templates/ProjectTemplates.nuspec
@@ -16,12 +16,14 @@
     <file src="ProjectTemplate/CSharp/_gitignore" target="content/ProjectTemplate-CSharp/_gitignore" />
     <file src="ProjectTemplate/CSharp/Company.FunctionApp.csproj" target="content/ProjectTemplate-CSharp/Company.FunctionApp.csproj" />
     <file src="ProjectTemplate/CSharp/host.json" target="content/ProjectTemplate-CSharp/host.json" />
+    <file src="ProjectTemplate/CSharp/proxies.json" target="content/ProjectTemplate-CSharp/proxies.json" />
     <file src="ProjectTemplate/CSharp/local.settings.json" target="content/ProjectTemplate-CSharp/local.settings.json" />
     <file src="ProjectTemplate/CSharp/build.config/template.json" target="content/ProjectTemplate-CSharp/.template.config/template.json" />
     <file src="ProjectTemplate/CSharp/build.config/dotnetcli.host.json" target="content/ProjectTemplate-CSharp/.template.config/dotnetcli.host.json" />
     <file src="ProjectTemplate/FSharp/_gitignore" target="content/ProjectTemplate-FSharp/_gitignore" />
     <file src="ProjectTemplate/FSharp/Company.FunctionApp.fsproj" target="content/ProjectTemplate-FSharp/Company.FunctionApp.fsproj" />
     <file src="ProjectTemplate/FSharp/host.json" target="content/ProjectTemplate-FSharp/host.json" />
+    <file src="ProjectTemplate/FSharp/proxies.json" target="content/ProjectTemplate-FSharp/proxies.json" />
     <file src="ProjectTemplate/FSharp/local.settings.json" target="content/ProjectTemplate-FSharp/local.settings.json" />
     <file src="ProjectTemplate/FSharp/build.config/template.json" target="content/ProjectTemplate-FSharp/.template.config/template.json" />
     <file src="ProjectTemplate/FSharp/build.config/dotnetcli.host.json" target="content/ProjectTemplate-FSharp/.template.config/dotnetcli.host.json" />


### PR DESCRIPTION
Added empty proxies.json file to C# & F# templates with 'Copy to Output Directory' set to 'Copy if Newer' . IMO more developer friendly as the file is already there and being published. This way, when they add proxies after the functions have already been built it is already configured. Additionally they can just delete the file if they are not using. 