### PR TITLE
fix some style issues

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-PowerShell/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-PowerShell/function.json
@@ -5,7 +5,7 @@
       "authLevel": "function",
       "type": "httpTrigger",
       "direction": "in",
-      "name": "req",
+      "name": "Request",
       "methods": [
         "get",
         "post"
@@ -14,7 +14,7 @@
     {
       "type": "http",
       "direction": "out",
-      "name": "res"
+      "name": "Response"
     }
   ]
 }

--- a/Functions.Templates/Templates/HttpTrigger-PowerShell/run.ps1
+++ b/Functions.Templates/Templates/HttpTrigger-PowerShell/run.ps1
@@ -1,24 +1,28 @@
+using namespace System.Net
+
 # Input bindings are passed in via param block.
-param($req, $TriggerMetadata)
+param($Request, $TriggerMetadata)
 
 # Write to the Azure Functions Trace-level log stream.
 Write-Verbose "PowerShell HTTP trigger function processed a request." -Verbose
 
-# Interact with query parameters, the body of the request, etc.
-$name = $req.Query.Name
-if (-not $name) { $name = $req.Body.Name }
+# Interact with query parameters or the body of the request.
+$name = $Request.Query.Name
+if (-not $name) {
+    $name = $Request.Body.Name
+}
 
-if($name) {
-    $status = 200
-    $body = "Hello " + $name
+if ($name) {
+    $status = [HttpStatusCode]::OK
+    $body = "Hello $name"
 }
 else {
-    $status = 400
+    $status = [HttpStatusCode]::BadRequest
     $body = "Please pass a name on the query string or in the request body."
 }
 
 # Associate values to output bindings by calling 'Push-OutputBinding'.
-Push-OutputBinding -Name res -Value ([HttpResponseContext]@{
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
     StatusCode = $status
     Body = $body
 })

--- a/Functions.Templates/Templates/HttpTrigger-PowerShell/run.ps1
+++ b/Functions.Templates/Templates/HttpTrigger-PowerShell/run.ps1
@@ -3,8 +3,8 @@ using namespace System.Net
 # Input bindings are passed in via param block.
 param($Request, $TriggerMetadata)
 
-# Write to the Azure Functions Trace-level log stream.
-Write-Verbose "PowerShell HTTP trigger function processed a request." -Verbose
+# Write to the Azure Functions log stream.
+Write-Host "PowerShell HTTP trigger function processed a request."
 
 # Interact with query parameters or the body of the request.
 $name = $Request.Query.Name


### PR DESCRIPTION
- `req` and `res` is taken from the C# sample, but for PowerShell scripters, it's better to have the parameter names spelled out
- use `HttpStatusCode` type instead of magic numbers
- consistent formatting of braces

cc @daxian-dbw @tylerl0706