### PR TITLE
Wrong casing in TimerTrigger JavaScript/Typescript `isPastDue`

### DIFF
--- a/Functions.Templates/Documentation/eventHubOut.md
+++ b/Functions.Templates/Documentation/eventHubOut.md
@@ -30,7 +30,7 @@ This example uses a Timer Trigger input, but Event Hubs output can work with any
 	module.exports = function (context, myTimer) {
 	    var timeStamp = new Date().toISOString();
 	    
-	    if(myTimer.IsPastDue)
+	    if (myTimer.IsPastDue)
 	    {
 	        context.log('TimerTriggerJS1 is running late!');
 	    }

--- a/Functions.Templates/Documentation/eventHubOut.md
+++ b/Functions.Templates/Documentation/eventHubOut.md
@@ -30,7 +30,7 @@ This example uses a Timer Trigger input, but Event Hubs output can work with any
 	module.exports = function (context, myTimer) {
 	    var timeStamp = new Date().toISOString();
 	    
-	    if(myTimer.isPastDue)
+	    if(myTimer.IsPastDue)
 	    {
 	        context.log('TimerTriggerJS1 is running late!');
 	    }

--- a/Functions.Templates/Documentation/notificationHubOut.md
+++ b/Functions.Templates/Documentation/notificationHubOut.md
@@ -27,7 +27,7 @@ This example sends a notification for a [template registration](https://azure.mi
 module.exports = function (context, myTimer) {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.isPastDue)
+    if(myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Documentation/notificationHubOut.md
+++ b/Functions.Templates/Documentation/notificationHubOut.md
@@ -27,7 +27,7 @@ This example sends a notification for a [template registration](https://azure.mi
 module.exports = function (context, myTimer) {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.IsPastDue)
+    if (myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Documentation/timerTrigger.md
+++ b/Functions.Templates/Documentation/timerTrigger.md
@@ -68,7 +68,7 @@ public static void Run(TimerInfo myTimer, ILogger log)
 
 ```JavaScript
 module.exports = function(context, myTimer) {
-    if(myTimer.isPastDue)
+    if(myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Documentation/timerTrigger.md
+++ b/Functions.Templates/Documentation/timerTrigger.md
@@ -68,7 +68,7 @@ public static void Run(TimerInfo myTimer, ILogger log)
 
 ```JavaScript
 module.exports = function(context, myTimer) {
-    if(myTimer.IsPastDue)
+    if (myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Templates/TimerTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates/TimerTrigger-JavaScript/index.js
@@ -1,7 +1,7 @@
 module.exports = async function (context, myTimer) {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.isPastDue)
+    if(myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Templates/TimerTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates/TimerTrigger-JavaScript/index.js
@@ -1,7 +1,7 @@
 module.exports = async function (context, myTimer) {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.IsPastDue)
+    if (myTimer.IsPastDue)
     {
         context.log('JavaScript is running late!');
     }

--- a/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
@@ -3,7 +3,7 @@ import { AzureFunction, Context } from "@azure/functions"
 const timerTrigger: AzureFunction = async function (context: Context, myTimer: any): Promise<void> {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.isPastDue)
+    if(myTimer.IsPastDue)
     {
         context.log('Timer function is running late!');
     }

--- a/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
@@ -3,7 +3,7 @@ import { AzureFunction, Context } from "@azure/functions"
 const timerTrigger: AzureFunction = async function (context: Context, myTimer: any): Promise<void> {
     var timeStamp = new Date().toISOString();
     
-    if(myTimer.IsPastDue)
+    if (myTimer.IsPastDue)
     {
         context.log('Timer function is running late!');
     }


### PR DESCRIPTION
isPastDue should be IsPastDue. In V1, there used to be hard coded logic to make this lower case (https://github.com/Azure/azure-functions-host/blob/2a73a53260b55e8abc61c34da39be04244e5a957/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs#L406). In V2, this custom logic doesn't happen.