### PR TITLE
Project template name looks better with a space

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/build.config/template.json
+++ b/Functions.Templates/ProjectTemplate/CSharp/build.config/template.json
@@ -4,7 +4,7 @@
         "Azure Functions",
         "Solution"
     ],
-    "name": "AzureFunctions",
+    "name": "Azure Functions",
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",


### PR DESCRIPTION
Currently looks quite ugly when running `dotnet new-l`:

```
Templates                                         Short Name           Language          Tags
------------------------------------------------------------------------------------------------------------------------------
AzureFunctions                                    func                 [C#], F#          Azure Functions/Solution
Console Application                               console              [C#], F#, VB      Common/Console
Class library                                     classlib             [C#], F#, VB      Common/Library
...
```

Same in graphical tools:

![image](https://user-images.githubusercontent.com/485230/55070228-12a2a700-5086-11e9-80aa-ccd5f7721b5c.png)