### PR TITLE
#876 python queue tempate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Publish
 tools
 /node_modules
 /.output
+
+.env

--- a/Functions.Templates/Templates/QueueTrigger-Python/README.md
+++ b/Functions.Templates/Templates/QueueTrigger-Python/README.md
@@ -1,4 +1,4 @@
-# QueueTrigger - Python
+# Python QueueTrigger
 
 The `QueueTrigger` makes it incredibly easy to react to new Queues inside of Azure Queue Storage. This sample demonstrates a simple use case of processing data from a given Queue.
 

--- a/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
+++ b/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
@@ -3,7 +3,7 @@ import logging
 import azure.functions as func
 
 
-def main(msg: func.QueueMessage) -> None:
+def main(message: func.QueueMessage) -> None:
     logging.info(
         "Python queue trigger function processed a queue item: %s",
         msg.get_body().decode("utf-8"),

--- a/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
+++ b/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
@@ -4,7 +4,9 @@ import azure.functions as func
 
 
 def main(message: func.QueueMessage) -> None:
-    logging.info(
-        "Python queue trigger function processed a queue item: %s",
-        msg.get_body().decode("utf-8"),
-    )
+    # Log the received message as plaintext.
+
+    # The `message` argument
+    message = message.get_body().decode("utf-8")
+
+    logging.info("Python queue trigger function processed a queue item: " + message)

--- a/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
+++ b/Functions.Templates/Templates/QueueTrigger-Python/__init__.py
@@ -4,5 +4,7 @@ import azure.functions as func
 
 
 def main(msg: func.QueueMessage) -> None:
-    logging.info('Python queue trigger function processed a queue item: %s',
-                 msg.get_body().decode('utf-8'))
+    logging.info(
+        "Python queue trigger function processed a queue item: %s",
+        msg.get_body().decode("utf-8"),
+    )

--- a/Functions.Templates/Templates/QueueTrigger-Python/function.json
+++ b/Functions.Templates/Templates/QueueTrigger-Python/function.json
@@ -2,11 +2,11 @@
     "scriptFile": "__init__.py",
     "bindings": [
         {
-            "name": "msg",
+            "name": "message",
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "python-queue-items",
-            "connection":""
+            "connection": ""
         }
     ]
 }


### PR DESCRIPTION
This PR addresses Issue #876.

- Uses Black formatting.
- Renames `msg` to `message`. 
- Splits logging to a nicer format.
- Renames `readme` to `README`.

There is still work to be done, I just wanted to start getting some feedback so I can move in the right direction.