### PR TITLE
Treat id for cosmos db document as key

### DIFF
--- a/Functions.Templates/Templates/CosmosDBTrigger-Python/__init__.py
+++ b/Functions.Templates/Templates/CosmosDBTrigger-Python/__init__.py
@@ -5,4 +5,4 @@ import azure.functions as func
 
 def main(documents: func.DocumentList) -> str:
     if documents:
-        logging.info('Document id: %s', documents[0].id)
+        logging.info('Document id: %s', documents[0]['id'])


### PR DESCRIPTION
Fixing default template experience for Python to be in line with published docs: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2#trigger---python-example. 