### PR TITLE
Project template name looks better with a space

### DIFF
--- a/Functions.Templates/ProjectTemplate/FSharp/build.config/template.json
+++ b/Functions.Templates/ProjectTemplate/FSharp/build.config/template.json
@@ -4,7 +4,7 @@
         "Azure Functions",
         "Solution"
     ],
-    "name": "AzureFunctions",
+    "name": "Azure Functions",
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-functions-templates/pull/856 (but this time for the FSharp template)