### PR TITLE
Updated Durable Functions extension to 1.8.3

### DIFF
--- a/FallBackFolderBuild/extensions.json
+++ b/FallBackFolderBuild/extensions.json
@@ -21,7 +21,7 @@
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2"
+        "version": "1.8.3"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.EventGrid",

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -2004,7 +2004,7 @@
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2"
+        "version": "1.8.3"
       },
       "settings": [
         {
@@ -2038,7 +2038,7 @@
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2"
+        "version": "1.8.3"
       },
       "settings": [
         {
@@ -2072,7 +2072,7 @@
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2"
+        "version": "1.8.3"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-JavaScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-TypeScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/build.config/template.json
@@ -35,7 +35,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2",
+        "version": "1.8.3",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-JavaScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }


### PR DESCRIPTION
This PR updates the templates to the latest version of the Durable Functions nuget extension:
https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask/1.8.3

Release notes:
https://github.com/Azure/azure-functions-durable-extension/releases