### PR TITLE
Change auth defaults to 'anonymous' in function.json

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-JavaScript/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-JavaScript/function.json
@@ -1,7 +1,7 @@
 {
     "bindings": [
         {
-            "authLevel": "function",
+            "authLevel": "anonymous",
             "type": "httpTrigger",
             "direction": "in",
             "name": "req",

--- a/Functions.Templates/Templates/HttpTrigger-PowerShell/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-PowerShell/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "Request",

--- a/Functions.Templates/Templates/HttpTrigger-Python/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-Python/function.json
@@ -2,7 +2,7 @@
     "scriptFile": "__init__.py",
     "bindings": [
         {
-            "authLevel": "function",
+            "authLevel": "anonymous",
             "type": "httpTrigger",
             "direction": "in",
             "name": "req",

--- a/Functions.Templates/Templates/HttpTrigger-TypeScript/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-TypeScript/function.json
@@ -1,7 +1,7 @@
 {
     "bindings": [
         {
-            "authLevel": "function",
+            "authLevel": "anonymous",
             "type": "httpTrigger",
             "direction": "in",
             "name": "req",


### PR DESCRIPTION
This PR updates the HTTP triggered function to switch the default authorization to `anonymous` , which recent UX testing has shown to be more successful in quickstarts. Because the Core Tools uses these defaults, we need to make these updates to streamline the Core Tools quickstart(s).