### PR TITLE
Enable authLevel prompt for durable http starter functions

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
@@ -9,7 +9,9 @@
   ],
   "categoryStyle": "other",
   "enabledInTryMode": false,
-  "userPrompt": [],
+  "userPrompt": [
+    "authLevel"
+  ],
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.5"

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
@@ -9,7 +9,9 @@
   ],
   "categoryStyle": "other",
   "enabledInTryMode": false,
-  "userPrompt": [],
+  "userPrompt": [
+    "authLevel"
+  ],
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.5"

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
@@ -9,7 +9,9 @@
   ],
   "categoryStyle": "other",
   "enabledInTryMode": false,
-  "userPrompt": [],
+  "userPrompt": [
+    "authLevel"
+  ],
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.5"


### PR DESCRIPTION
Seems like [this change](https://github.com/Azure/azure-functions-templates/pull/900) was recently pushed to the staging templates for v2, but it makes it annoying for our unit tests in VS Code if v2 and v3 templates are different. So I cherry picked the commit over to the v3 branch