### PR TITLE
Fix excludedTypes settings in generated host.json

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/host.json
+++ b/Functions.Templates/ProjectTemplate/CSharp/host.json
@@ -2,9 +2,9 @@
     "version": "2.0",
     "logging": {
         "applicationInsights": {
-            "samplingExcludedTypes": "Request",
             "samplingSettings": {
-                "isEnabled": true
+                "isEnabled": true,
+                "excludedTypes": "Request"
             }
         }
     }

--- a/Functions.Templates/ProjectTemplate/FSharp/host.json
+++ b/Functions.Templates/ProjectTemplate/FSharp/host.json
@@ -2,9 +2,9 @@
     "version": "2.0",
     "logging": {
         "applicationInsights": {
-            "samplingExcludedTypes": "Request",
             "samplingSettings": {
-                "isEnabled": true
+                "isEnabled": true,
+                "excludedTypes": "Request"
             }
         }
     }


### PR DESCRIPTION
Seems like the `samplingExcludedTypes` is actually under `samplingSettings` and is simply `excludedTypes` itself as seen in [this line](https://github.com/Azure/azure-functions-host/blob/123813c244919360c4fbd54f01ee52986989562b/src/WebJobs.Script/Config/ApplicationInsightsLoggerOptionsSetup.cs#L58).

This was brought up on a [docs issue](https://github.com/MicrosoftDocs/azure-docs/issues/50233) since this file is used for new projects.