### PR TITLE
Explicitly including Functions json files

### DIFF
--- a/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
@@ -8,10 +8,10 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.36" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="host.json">
+    <None Include="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="local.settings.json">
+    <None Include="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>


### PR DESCRIPTION
As noted in https://github.com/Azure/azure-functions-core-tools/issues/1963#issuecomment-641019816 because F# requires all files to be explicitly included with MSBuild, using `Update` rather than `Include` for the `host.json` and `local.settings.json` will result in them not being included and likely resulting in a failure to run `func start`.

This may also be related to https://github.com/Azure/azure-functions-durable-extension/issues/1140