### PR TITLE
Port templates for custom handlers (#964)

### DIFF
--- a/Build/PackageFiles/ExtensionBundleTemplates-1.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundleTemplates-1.x.nuspec
@@ -39,19 +39,28 @@
     <file src="templates/BlobTrigger-JavaScript/metadata.json" target="templates/BlobTrigger-JavaScript/metadata.json" />
     <file src="templates/BlobTrigger-JavaScript/readme.md" target="templates/BlobTrigger-JavaScript/readme.md" />
     <file src="templates/BlobTrigger-JavaScript/sample.dat" target="templates/BlobTrigger-JavaScript/sample.dat" />
+    <file src="templates/BlobTrigger-Custom/function.json" target="templates/BlobTrigger-Custom/function.json" />
+    <file src="templates/BlobTrigger-Custom/metadata.json" target="templates/BlobTrigger-Custom/metadata.json" />
     <file src="templates/HttpTrigger-JavaScript/function.json" target="templates/HttpTrigger-JavaScript/function.json" />
     <file src="templates/HttpTrigger-JavaScript/index.js" target="templates/HttpTrigger-JavaScript/index.js" />
     <file src="templates/HttpTrigger-JavaScript/metadata.json" target="templates/HttpTrigger-JavaScript/metadata.json" />
     <file src="templates/HttpTrigger-JavaScript/sample.dat" target="templates/HttpTrigger-JavaScript/sample.dat" />
+    <file src="templates/HttpTrigger-Custom/function.json" target="templates/HttpTrigger-Custom/function.json" />
+    <file src="templates/HttpTrigger-Custom/metadata.json" target="templates/HttpTrigger-Custom/metadata.json" />
     <file src="templates/QueueTrigger-JavaScript/function.json" target="templates/QueueTrigger-JavaScript/function.json" />
     <file src="templates/QueueTrigger-JavaScript/index.js" target="templates/QueueTrigger-JavaScript/index.js" />
     <file src="templates/QueueTrigger-JavaScript/metadata.json" target="templates/QueueTrigger-JavaScript/metadata.json" />
     <file src="templates/QueueTrigger-JavaScript/readme.md" target="templates/QueueTrigger-JavaScript/readme.md" />
     <file src="templates/QueueTrigger-JavaScript/sample.dat" target="templates/QueueTrigger-JavaScript/sample.dat" />
+    <file src="templates/QueueTrigger-Custom/function.json" target="templates/QueueTrigger-Custom/function.json" />
+    <file src="templates/QueueTrigger-Custom/metadata.json" target="templates/QueueTrigger-Custom/metadata.json" />
     <file src="templates/TimerTrigger-JavaScript/function.json" target="templates/TimerTrigger-JavaScript/function.json" />
     <file src="templates/TimerTrigger-JavaScript/index.js" target="templates/TimerTrigger-JavaScript/index.js" />
     <file src="templates/TimerTrigger-JavaScript/metadata.json" target="templates/TimerTrigger-JavaScript/metadata.json" />
     <file src="templates/TimerTrigger-JavaScript/sample.dat" target="templates/TimerTrigger-JavaScript/sample.dat" />
+    <file src="templates/TimerTrigger-JavaScript/readme.md" target="templates/TimerTrigger-JavaScript/readme.md" />
+    <file src="templates/TimerTrigger-Custom/function.json" target="templates/TimerTrigger-Custom/function.json" />
+    <file src="templates/TimerTrigger-Custom/metadata.json" target="templates/TimerTrigger-Custom/metadata.json" />
     <file src="templates/BlobTrigger-TypeScript/function.json" target="templates/BlobTrigger-TypeScript/function.json" />
     <file src="templates/BlobTrigger-TypeScript/index.ts" target="templates/BlobTrigger-TypeScript/index.ts" />
     <file src="templates/BlobTrigger-TypeScript/metadata.json" target="templates/BlobTrigger-TypeScript/metadata.json" />
@@ -95,8 +104,9 @@
     <file src="templates/EventHubTrigger-JavaScript/index.js" target="templates/EventHubTrigger-JavaScript/index.js" />
     <file src="templates/EventHubTrigger-JavaScript/metadata.json" target="templates/EventHubTrigger-JavaScript/metadata.json" />
     <file src="templates/EventHubTrigger-JavaScript/function.json" target="templates/EventHubTrigger-JavaScript/function.json" />
-    <file src="templates/TimerTrigger-JavaScript/readme.md" target="templates/TimerTrigger-JavaScript/readme.md" />
     <file src="templates/EventHubTrigger-JavaScript/sample.dat" target="templates/EventHubTrigger-JavaScript/sample.dat" />
+    <file src="templates/EventHubTrigger-Custom/metadata.json" target="templates/EventHubTrigger-Custom/metadata.json" />
+    <file src="templates/EventHubTrigger-Custom/function.json" target="templates/EventHubTrigger-Custom/function.json" />
     <file src="templates/EventHubTrigger-TypeScript/index.ts" target="templates/EventHubTrigger-TypeScript/index.ts" />
     <file src="templates/EventHubTrigger-TypeScript/metadata.json" target="templates/EventHubTrigger-TypeScript/metadata.json" />
     <file src="templates/EventHubTrigger-TypeScript/function.json" target="templates/EventHubTrigger-TypeScript/function.json" />
@@ -137,6 +147,8 @@
     <file src="templates/SendGrid-JavaScript/metadata.json" target="templates/SendGrid-JavaScript/metadata.json" />
     <file src="templates/SendGrid-JavaScript/index.js" target="templates/SendGrid-JavaScript/index.js" />
     <file src="templates/SendGrid-JavaScript/sample.dat" target="templates/SendGrid-JavaScript/sample.dat" />
+    <file src="templates/SendGrid-Custom/function.json" target="templates/SendGrid-Custom/function.json" />
+    <file src="templates/SendGrid-Custom/metadata.json" target="templates/SendGrid-Custom/metadata.json" />
     <file src="templates/SendGrid-TypeScript/function.json" target="templates/SendGrid-TypeScript/function.json" />
     <file src="templates/SendGrid-TypeScript/metadata.json" target="templates/SendGrid-TypeScript/metadata.json" />
     <file src="templates/SendGrid-TypeScript/index.ts" target="templates/SendGrid-TypeScript/index.ts" />
@@ -149,6 +161,8 @@
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/index.js" target="Templates/ServiceBusQueueTrigger-JavaScript/index.js" />
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/metadata.json" target="Templates/ServiceBusQueueTrigger-JavaScript/metadata.json" />
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/sample.dat" target="Templates/ServiceBusQueueTrigger-JavaScript/sample.dat" />
+    <file src="Templates/ServiceBusQueueTrigger-Custom/function.json" target="Templates/ServiceBusQueueTrigger-Custom/function.json" />
+    <file src="Templates/ServiceBusQueueTrigger-Custom/metadata.json" target="Templates/ServiceBusQueueTrigger-Custom/metadata.json" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/function.json" target="Templates/ServiceBusQueueTrigger-TypeScript/function.json" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/index.ts" target="Templates/ServiceBusQueueTrigger-TypeScript/index.ts" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/metadata.json" target="Templates/ServiceBusQueueTrigger-TypeScript/metadata.json" />
@@ -161,6 +175,8 @@
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/index.js" target="Templates/ServiceBusTopicTrigger-JavaScript/index.js" />
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/metadata.json" target="Templates/ServiceBusTopicTrigger-JavaScript/metadata.json" />
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/sample.dat" target="Templates/ServiceBusTopicTrigger-JavaScript/sample.dat" />
+    <file src="Templates/ServiceBusTopicTrigger-Custom/function.json" target="Templates/ServiceBusTopicTrigger-Custom/function.json" />
+    <file src="Templates/ServiceBusTopicTrigger-Custom/metadata.json" target="Templates/ServiceBusTopicTrigger-Custom/metadata.json" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/function.json" target="Templates/ServiceBusTopicTrigger-TypeScript/function.json" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/index.ts" target="Templates/ServiceBusTopicTrigger-TypeScript/index.ts" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/metadata.json" target="Templates/ServiceBusTopicTrigger-TypeScript/metadata.json" />
@@ -172,6 +188,8 @@
     <file src="Templates/CosmosDBTrigger-JavaScript/metadata.json" target="Templates/CosmosDBTrigger-JavaScript/metadata.json" />
     <file src="Templates/CosmosDBTrigger-JavaScript/index.js" target="Templates/CosmosDBTrigger-JavaScript/index.js" />
     <file src="Templates/CosmosDBTrigger-JavaScript/sample.dat" target="Templates/CosmosDBTrigger-JavaScript/sample.dat" />
+    <file src="Templates/CosmosDBTrigger-Custom/function.json" target="Templates/CosmosDBTrigger-Custom/function.json" />
+    <file src="Templates/CosmosDBTrigger-Custom/metadata.json" target="Templates/CosmosDBTrigger-Custom/metadata.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/function.json" target="Templates/CosmosDBTrigger-TypeScript/function.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/metadata.json" target="Templates/CosmosDBTrigger-TypeScript/metadata.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/index.ts" target="Templates/CosmosDBTrigger-TypeScript/index.ts" />
@@ -188,6 +206,8 @@
     <file src="Templates/IoTHubTrigger-JavaScript/index.js" target="Templates/IoTHubTrigger-JavaScript/index.js" />
     <file src="Templates/IoTHubTrigger-JavaScript/metadata.json" target="Templates/IoTHubTrigger-JavaScript/metadata.json" />
     <file src="Templates/IoTHubTrigger-JavaScript/sample.dat" target="Templates/IoTHubTrigger-JavaScript/sample.dat" />
+    <file src="Templates/IoTHubTrigger-Custom/function.json" target="Templates/IoTHubTrigger-Custom/function.json" />
+    <file src="Templates/IoTHubTrigger-Custom/metadata.json" target="Templates/IoTHubTrigger-Custom/metadata.json" />
     <file src="Templates/IoTHubTrigger-TypeScript/function.json" target="Templates/IoTHubTrigger-TypeScript/function.json" />
     <file src="Templates/IoTHubTrigger-TypeScript/index.ts" target="Templates/IoTHubTrigger-TypeScript/index.ts" />
     <file src="Templates/IoTHubTrigger-TypeScript/metadata.json" target="Templates/IoTHubTrigger-TypeScript/metadata.json" />
@@ -200,6 +220,8 @@
     <file src="Templates/EventGridTrigger-JavaScript/function.json" target="Templates/EventGridTrigger-JavaScript/function.json" />
     <file src="Templates/EventGridTrigger-JavaScript/metadata.json" target="Templates/EventGridTrigger-JavaScript/metadata.json" />
     <file src="Templates/EventGridTrigger-JavaScript/sample.dat" target="Templates/EventGridTrigger-JavaScript/sample.dat" />
+    <file src="Templates/EventGridTrigger-Custom/function.json" target="Templates/EventGridTrigger-Custom/function.json" />
+    <file src="Templates/EventGridTrigger-Custom/metadata.json" target="Templates/EventGridTrigger-Custom/metadata.json" />
     <file src="Templates/EventGridTrigger-TypeScript/index.ts" target="Templates/EventGridTrigger-TypeScript/index.ts" />
     <file src="Templates/EventGridTrigger-TypeScript/function.json" target="Templates/EventGridTrigger-TypeScript/function.json" />
     <file src="Templates/EventGridTrigger-TypeScript/metadata.json" target="Templates/EventGridTrigger-TypeScript/metadata.json" />
@@ -271,6 +293,8 @@
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" />
+    <file src="Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" />
+    <file src="Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" />

--- a/Build/PackageFiles/ExtensionBundleTemplates-2.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundleTemplates-2.x.nuspec
@@ -39,19 +39,28 @@
     <file src="templates/BlobTrigger-JavaScript/metadata.json" target="templates/BlobTrigger-JavaScript/metadata.json" />
     <file src="templates/BlobTrigger-JavaScript/readme.md" target="templates/BlobTrigger-JavaScript/readme.md" />
     <file src="templates/BlobTrigger-JavaScript/sample.dat" target="templates/BlobTrigger-JavaScript/sample.dat" />
+    <file src="templates/BlobTrigger-Custom/function.json" target="templates/BlobTrigger-Custom/function.json" />
+    <file src="templates/BlobTrigger-Custom/metadata.json" target="templates/BlobTrigger-Custom/metadata.json" />
     <file src="templates/HttpTrigger-JavaScript/function.json" target="templates/HttpTrigger-JavaScript/function.json" />
     <file src="templates/HttpTrigger-JavaScript/index.js" target="templates/HttpTrigger-JavaScript/index.js" />
     <file src="templates/HttpTrigger-JavaScript/metadata.json" target="templates/HttpTrigger-JavaScript/metadata.json" />
     <file src="templates/HttpTrigger-JavaScript/sample.dat" target="templates/HttpTrigger-JavaScript/sample.dat" />
+    <file src="templates/HttpTrigger-Custom/function.json" target="templates/HttpTrigger-Custom/function.json" />
+    <file src="templates/HttpTrigger-Custom/metadata.json" target="templates/HttpTrigger-Custom/metadata.json" />
     <file src="templates/QueueTrigger-JavaScript/function.json" target="templates/QueueTrigger-JavaScript/function.json" />
     <file src="templates/QueueTrigger-JavaScript/index.js" target="templates/QueueTrigger-JavaScript/index.js" />
     <file src="templates/QueueTrigger-JavaScript/metadata.json" target="templates/QueueTrigger-JavaScript/metadata.json" />
     <file src="templates/QueueTrigger-JavaScript/readme.md" target="templates/QueueTrigger-JavaScript/readme.md" />
     <file src="templates/QueueTrigger-JavaScript/sample.dat" target="templates/QueueTrigger-JavaScript/sample.dat" />
+    <file src="templates/QueueTrigger-Custom/function.json" target="templates/QueueTrigger-Custom/function.json" />
+    <file src="templates/QueueTrigger-Custom/metadata.json" target="templates/QueueTrigger-Custom/metadata.json" />
     <file src="templates/TimerTrigger-JavaScript/function.json" target="templates/TimerTrigger-JavaScript/function.json" />
     <file src="templates/TimerTrigger-JavaScript/index.js" target="templates/TimerTrigger-JavaScript/index.js" />
     <file src="templates/TimerTrigger-JavaScript/metadata.json" target="templates/TimerTrigger-JavaScript/metadata.json" />
     <file src="templates/TimerTrigger-JavaScript/sample.dat" target="templates/TimerTrigger-JavaScript/sample.dat" />
+    <file src="templates/TimerTrigger-JavaScript/readme.md" target="templates/TimerTrigger-JavaScript/readme.md" />
+    <file src="templates/TimerTrigger-Custom/function.json" target="templates/TimerTrigger-Custom/function.json" />
+    <file src="templates/TimerTrigger-Custom/metadata.json" target="templates/TimerTrigger-Custom/metadata.json" />
     <file src="templates/BlobTrigger-TypeScript/function.json" target="templates/BlobTrigger-TypeScript/function.json" />
     <file src="templates/BlobTrigger-TypeScript/index.ts" target="templates/BlobTrigger-TypeScript/index.ts" />
     <file src="templates/BlobTrigger-TypeScript/metadata.json" target="templates/BlobTrigger-TypeScript/metadata.json" />
@@ -95,14 +104,15 @@
     <file src="templates/EventHubTrigger-JavaScript/index.js" target="templates/EventHubTrigger-JavaScript/index.js" />
     <file src="templates/EventHubTrigger-JavaScript/metadata.json" target="templates/EventHubTrigger-JavaScript/metadata.json" />
     <file src="templates/EventHubTrigger-JavaScript/function.json" target="templates/EventHubTrigger-JavaScript/function.json" />
-    <file src="templates/TimerTrigger-JavaScript/readme.md" target="templates/TimerTrigger-JavaScript/readme.md" />
     <file src="templates/EventHubTrigger-JavaScript/sample.dat" target="templates/EventHubTrigger-JavaScript/sample.dat" />
+    <file src="templates/EventHubTrigger-Custom/metadata.json" target="templates/EventHubTrigger-Custom/metadata.json" />
+    <file src="templates/EventHubTrigger-Custom/function.json" target="templates/EventHubTrigger-Custom/function.json" />
     <file src="templates/EventHubTrigger-TypeScript/index.ts" target="templates/EventHubTrigger-TypeScript/index.ts" />
     <file src="templates/EventHubTrigger-TypeScript/metadata.json" target="templates/EventHubTrigger-TypeScript/metadata.json" />
     <file src="templates/EventHubTrigger-TypeScript/function.json" target="templates/EventHubTrigger-TypeScript/function.json" />
     <file src="templates/TimerTrigger-TypeScript/readme.md" target="templates/TimerTrigger-TypeScript/readme.md" />
     <file src="templates/EventHubTrigger-TypeScript/sample.dat" target="templates/EventHubTrigger-TypeScript/sample.dat" />
-    <file src="templates/DurableFunctionsActivity-CSharp-2.x/function.json" target="templates/DurableFunctionsActivity-CSharp-2.x/function.json" />
+     <file src="templates/DurableFunctionsActivity-CSharp-2.x/function.json" target="templates/DurableFunctionsActivity-CSharp-2.x/function.json" />
     <file src="templates/DurableFunctionsActivity-CSharp-2.x/metadata.json" target="templates/DurableFunctionsActivity-CSharp-2.x/metadata.json" />
     <file src="templates/DurableFunctionsActivity-CSharp-2.x/DurableFunctionsActivityCSharp.csx" target="templates/DurableFunctionsActivity-CSharp-2.x/run.csx" />
     <file src="templates/DurableFunctionsActivity-JavaScript/function.json" target="Templates/DurableFunctionsActivity-JavaScript/function.json" />
@@ -111,7 +121,7 @@
     <file src="templates/DurableFunctionsActivity-TypeScript/function.json" target="Templates/DurableFunctionsActivity-TypeScript/function.json" />
     <file src="templates/DurableFunctionsActivity-TypeScript/index.ts" target="templates/DurableFunctionsActivity-TypeScript/index.ts" />
     <file src="templates/DurableFunctionsActivity-TypeScript/metadata.json" target="Templates/DurableFunctionsActivity-TypeScript/metadata.json" />
-    <file src="templates/DurableFunctionsOrchestrator-CSharp-2.x/function.json" target="templates/DurableFunctionsOrchestrator-CSharp-2.x/function.json" />
+     <file src="templates/DurableFunctionsOrchestrator-CSharp-2.x/function.json" target="templates/DurableFunctionsOrchestrator-CSharp-2.x/function.json" />
     <file src="templates/DurableFunctionsOrchestrator-CSharp-2.x/metadata.json" target="templates/DurableFunctionsOrchestrator-CSharp-2.x/metadata.json" />
     <file src="templates/DurableFunctionsOrchestrator-CSharp-2.x/DurableFunctionsOrchestratorCSharp.csx" target="templates/DurableFunctionsOrchestrator-CSharp-2.x/run.csx" />
     <file src="templates/DurableFunctionsOrchestrator-JavaScript/function.json" target="Templates/DurableFunctionsOrchestrator-JavaScript/function.json" />
@@ -120,7 +130,7 @@
     <file src="templates/DurableFunctionsOrchestrator-TypeScript/function.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/function.json" />
     <file src="templates/DurableFunctionsOrchestrator-TypeScript/index.ts" target="templates/DurableFunctionsOrchestrator-TypeScript/index.ts" />
     <file src="templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" />
-    <file src="templates/DurableFunctionsHttpStart-CSharp-2.x/function.json" target="templates/DurableFunctionsHttpStart-CSharp-2.x/function.json" />
+     <file src="templates/DurableFunctionsHttpStart-CSharp-2.x/function.json" target="templates/DurableFunctionsHttpStart-CSharp-2.x/function.json" />
     <file src="templates/DurableFunctionsHttpStart-CSharp-2.x/metadata.json" target="templates/DurableFunctionsHttpStart-CSharp-2.x/metadata.json" />
     <file src="templates/DurableFunctionsHttpStart-CSharp-2.x/DurableFunctionsHttpStartCSharp.csx" target="templates/DurableFunctionsHttpStart-CSharp-2.x/run.csx" />
     <file src="templates/DurableFunctionsHttpStart-JavaScript/function.json" target="templates/DurableFunctionsHttpStart-JavaScript/function.json" />
@@ -137,6 +147,8 @@
     <file src="templates/SendGrid-JavaScript/metadata.json" target="templates/SendGrid-JavaScript/metadata.json" />
     <file src="templates/SendGrid-JavaScript/index.js" target="templates/SendGrid-JavaScript/index.js" />
     <file src="templates/SendGrid-JavaScript/sample.dat" target="templates/SendGrid-JavaScript/sample.dat" />
+    <file src="templates/SendGrid-Custom/function.json" target="templates/SendGrid-Custom/function.json" />
+    <file src="templates/SendGrid-Custom/metadata.json" target="templates/SendGrid-Custom/metadata.json" />
     <file src="templates/SendGrid-TypeScript/function.json" target="templates/SendGrid-TypeScript/function.json" />
     <file src="templates/SendGrid-TypeScript/metadata.json" target="templates/SendGrid-TypeScript/metadata.json" />
     <file src="templates/SendGrid-TypeScript/index.ts" target="templates/SendGrid-TypeScript/index.ts" />
@@ -149,6 +161,8 @@
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/index.js" target="Templates/ServiceBusQueueTrigger-JavaScript/index.js" />
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/metadata.json" target="Templates/ServiceBusQueueTrigger-JavaScript/metadata.json" />
     <file src="Templates/ServiceBusQueueTrigger-JavaScript/sample.dat" target="Templates/ServiceBusQueueTrigger-JavaScript/sample.dat" />
+    <file src="Templates/ServiceBusQueueTrigger-Custom/function.json" target="Templates/ServiceBusQueueTrigger-Custom/function.json" />
+    <file src="Templates/ServiceBusQueueTrigger-Custom/metadata.json" target="Templates/ServiceBusQueueTrigger-Custom/metadata.json" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/function.json" target="Templates/ServiceBusQueueTrigger-TypeScript/function.json" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/index.ts" target="Templates/ServiceBusQueueTrigger-TypeScript/index.ts" />
     <file src="Templates/ServiceBusQueueTrigger-TypeScript/metadata.json" target="Templates/ServiceBusQueueTrigger-TypeScript/metadata.json" />
@@ -161,6 +175,8 @@
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/index.js" target="Templates/ServiceBusTopicTrigger-JavaScript/index.js" />
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/metadata.json" target="Templates/ServiceBusTopicTrigger-JavaScript/metadata.json" />
     <file src="Templates/ServiceBusTopicTrigger-JavaScript/sample.dat" target="Templates/ServiceBusTopicTrigger-JavaScript/sample.dat" />
+    <file src="Templates/ServiceBusTopicTrigger-Custom/function.json" target="Templates/ServiceBusTopicTrigger-Custom/function.json" />
+    <file src="Templates/ServiceBusTopicTrigger-Custom/metadata.json" target="Templates/ServiceBusTopicTrigger-Custom/metadata.json" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/function.json" target="Templates/ServiceBusTopicTrigger-TypeScript/function.json" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/index.ts" target="Templates/ServiceBusTopicTrigger-TypeScript/index.ts" />
     <file src="Templates/ServiceBusTopicTrigger-TypeScript/metadata.json" target="Templates/ServiceBusTopicTrigger-TypeScript/metadata.json" />
@@ -172,6 +188,8 @@
     <file src="Templates/CosmosDBTrigger-JavaScript/metadata.json" target="Templates/CosmosDBTrigger-JavaScript/metadata.json" />
     <file src="Templates/CosmosDBTrigger-JavaScript/index.js" target="Templates/CosmosDBTrigger-JavaScript/index.js" />
     <file src="Templates/CosmosDBTrigger-JavaScript/sample.dat" target="Templates/CosmosDBTrigger-JavaScript/sample.dat" />
+    <file src="Templates/CosmosDBTrigger-Custom/function.json" target="Templates/CosmosDBTrigger-Custom/function.json" />
+    <file src="Templates/CosmosDBTrigger-Custom/metadata.json" target="Templates/CosmosDBTrigger-Custom/metadata.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/function.json" target="Templates/CosmosDBTrigger-TypeScript/function.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/metadata.json" target="Templates/CosmosDBTrigger-TypeScript/metadata.json" />
     <file src="Templates/CosmosDBTrigger-TypeScript/index.ts" target="Templates/CosmosDBTrigger-TypeScript/index.ts" />
@@ -188,6 +206,8 @@
     <file src="Templates/IoTHubTrigger-JavaScript/index.js" target="Templates/IoTHubTrigger-JavaScript/index.js" />
     <file src="Templates/IoTHubTrigger-JavaScript/metadata.json" target="Templates/IoTHubTrigger-JavaScript/metadata.json" />
     <file src="Templates/IoTHubTrigger-JavaScript/sample.dat" target="Templates/IoTHubTrigger-JavaScript/sample.dat" />
+    <file src="Templates/IoTHubTrigger-Custom/function.json" target="Templates/IoTHubTrigger-Custom/function.json" />
+    <file src="Templates/IoTHubTrigger-Custom/metadata.json" target="Templates/IoTHubTrigger-Custom/metadata.json" />
     <file src="Templates/IoTHubTrigger-TypeScript/function.json" target="Templates/IoTHubTrigger-TypeScript/function.json" />
     <file src="Templates/IoTHubTrigger-TypeScript/index.ts" target="Templates/IoTHubTrigger-TypeScript/index.ts" />
     <file src="Templates/IoTHubTrigger-TypeScript/metadata.json" target="Templates/IoTHubTrigger-TypeScript/metadata.json" />
@@ -200,6 +220,8 @@
     <file src="Templates/EventGridTrigger-JavaScript/function.json" target="Templates/EventGridTrigger-JavaScript/function.json" />
     <file src="Templates/EventGridTrigger-JavaScript/metadata.json" target="Templates/EventGridTrigger-JavaScript/metadata.json" />
     <file src="Templates/EventGridTrigger-JavaScript/sample.dat" target="Templates/EventGridTrigger-JavaScript/sample.dat" />
+    <file src="Templates/EventGridTrigger-Custom/function.json" target="Templates/EventGridTrigger-Custom/function.json" />
+    <file src="Templates/EventGridTrigger-Custom/metadata.json" target="Templates/EventGridTrigger-Custom/metadata.json" />
     <file src="Templates/EventGridTrigger-TypeScript/index.ts" target="Templates/EventGridTrigger-TypeScript/index.ts" />
     <file src="Templates/EventGridTrigger-TypeScript/function.json" target="Templates/EventGridTrigger-TypeScript/function.json" />
     <file src="Templates/EventGridTrigger-TypeScript/metadata.json" target="Templates/EventGridTrigger-TypeScript/metadata.json" />
@@ -271,6 +293,8 @@
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" />
+    <file src="Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" />
+    <file src="Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" />
     <file src="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" />

--- a/Build/PackageFiles/Templates.nuspec
+++ b/Build/PackageFiles/Templates.nuspec
@@ -39,19 +39,27 @@
     <file src="../../Functions.Templates/templates/BlobTrigger-JavaScript/metadata.json" target="templates/BlobTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/BlobTrigger-JavaScript/readme.md" target="templates/BlobTrigger-JavaScript/readme.md" />
     <file src="../../Functions.Templates/templates/BlobTrigger-JavaScript/sample.dat" target="templates/BlobTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/BlobTrigger-Custom/function.json" target="templates/BlobTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/BlobTrigger-Custom/metadata.json" target="templates/BlobTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/HttpTrigger-JavaScript/function.json" target="templates/HttpTrigger-JavaScript/function.json" />
     <file src="../../Functions.Templates/templates/HttpTrigger-JavaScript/index.js" target="templates/HttpTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/HttpTrigger-JavaScript/metadata.json" target="templates/HttpTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/HttpTrigger-JavaScript/sample.dat" target="templates/HttpTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/HttpTrigger-Custom/function.json" target="templates/HttpTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/HttpTrigger-Custom/metadata.json" target="templates/HttpTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/QueueTrigger-JavaScript/function.json" target="templates/QueueTrigger-JavaScript/function.json" />
     <file src="../../Functions.Templates/templates/QueueTrigger-JavaScript/index.js" target="templates/QueueTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/QueueTrigger-JavaScript/metadata.json" target="templates/QueueTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/QueueTrigger-JavaScript/readme.md" target="templates/QueueTrigger-JavaScript/readme.md" />
     <file src="../../Functions.Templates/templates/QueueTrigger-JavaScript/sample.dat" target="templates/QueueTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/QueueTrigger-Custom/function.json" target="templates/QueueTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/QueueTrigger-Custom/metadata.json" target="templates/QueueTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/TimerTrigger-JavaScript/function.json" target="templates/TimerTrigger-JavaScript/function.json" />
     <file src="../../Functions.Templates/templates/TimerTrigger-JavaScript/index.js" target="templates/TimerTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/TimerTrigger-JavaScript/metadata.json" target="templates/TimerTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/TimerTrigger-JavaScript/sample.dat" target="templates/TimerTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/TimerTrigger-Custom/function.json" target="templates/TimerTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/TimerTrigger-Custom/metadata.json" target="templates/TimerTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/BlobTrigger-TypeScript/function.json" target="templates/BlobTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/BlobTrigger-TypeScript/index.ts" target="templates/BlobTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/BlobTrigger-TypeScript/metadata.json" target="templates/BlobTrigger-TypeScript/metadata.json" />
@@ -95,6 +103,8 @@
     <file src="../../Functions.Templates/templates/EventHubTrigger-JavaScript/index.js" target="templates/EventHubTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/EventHubTrigger-JavaScript/metadata.json" target="templates/EventHubTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/EventHubTrigger-JavaScript/function.json" target="templates/EventHubTrigger-JavaScript/function.json" />
+    <file src="../../Functions.Templates/templates/EventHubTrigger-Custom/metadata.json" target="templates/EventHubTrigger-Custom/metadata.json" />
+    <file src="../../Functions.Templates/templates/EventHubTrigger-Custom/function.json" target="templates/EventHubTrigger-Custom/function.json" />
     <file src="../../Functions.Templates/templates/TimerTrigger-JavaScript/readme.md" target="templates/TimerTrigger-JavaScript/readme.md" />
     <file src="../../Functions.Templates/templates/EventHubTrigger-JavaScript/sample.dat" target="templates/EventHubTrigger-JavaScript/sample.dat" />
     <file src="../../Functions.Templates/templates/EventHubTrigger-TypeScript/index.ts" target="templates/EventHubTrigger-TypeScript/index.ts" />
@@ -137,6 +147,8 @@
     <file src="../../Functions.Templates/templates/SendGrid-JavaScript/metadata.json" target="templates/SendGrid-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/SendGrid-JavaScript/index.js" target="templates/SendGrid-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/SendGrid-JavaScript/sample.dat" target="templates/SendGrid-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/SendGrid-Custom/function.json" target="templates/SendGrid-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/SendGrid-Custom/metadata.json" target="templates/SendGrid-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/SendGrid-TypeScript/function.json" target="templates/SendGrid-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/SendGrid-TypeScript/metadata.json" target="templates/SendGrid-TypeScript/metadata.json" />
     <file src="../../Functions.Templates/templates/SendGrid-TypeScript/index.ts" target="templates/SendGrid-TypeScript/index.ts" />
@@ -149,6 +161,8 @@
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-JavaScript/index.js" target="Templates/ServiceBusQueueTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-JavaScript/metadata.json" target="Templates/ServiceBusQueueTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-JavaScript/sample.dat" target="Templates/ServiceBusQueueTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-Custom/function.json" target="Templates/ServiceBusQueueTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-Custom/metadata.json" target="Templates/ServiceBusQueueTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-TypeScript/function.json" target="Templates/ServiceBusQueueTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-TypeScript/index.ts" target="Templates/ServiceBusQueueTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/ServiceBusQueueTrigger-TypeScript/metadata.json" target="Templates/ServiceBusQueueTrigger-TypeScript/metadata.json" />
@@ -161,6 +175,8 @@
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-JavaScript/index.js" target="Templates/ServiceBusTopicTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-JavaScript/metadata.json" target="Templates/ServiceBusTopicTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-JavaScript/sample.dat" target="Templates/ServiceBusTopicTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-Custom/function.json" target="Templates/ServiceBusTopicTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-Custom/metadata.json" target="Templates/ServiceBusTopicTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-TypeScript/function.json" target="Templates/ServiceBusTopicTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-TypeScript/index.ts" target="Templates/ServiceBusTopicTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/ServiceBusTopicTrigger-TypeScript/metadata.json" target="Templates/ServiceBusTopicTrigger-TypeScript/metadata.json" />
@@ -172,6 +188,8 @@
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-JavaScript/metadata.json" target="Templates/CosmosDBTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-JavaScript/index.js" target="Templates/CosmosDBTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-JavaScript/sample.dat" target="Templates/CosmosDBTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/CosmosDBTrigger-Custom/function.json" target="Templates/CosmosDBTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/CosmosDBTrigger-Custom/metadata.json" target="Templates/CosmosDBTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-TypeScript/function.json" target="Templates/CosmosDBTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-TypeScript/metadata.json" target="Templates/CosmosDBTrigger-TypeScript/metadata.json" />
     <file src="../../Functions.Templates/templates/CosmosDBTrigger-TypeScript/index.ts" target="Templates/CosmosDBTrigger-TypeScript/index.ts" />
@@ -188,6 +206,8 @@
     <file src="../../Functions.Templates/templates/IoTHubTrigger-JavaScript/index.js" target="Templates/IoTHubTrigger-JavaScript/index.js" />
     <file src="../../Functions.Templates/templates/IoTHubTrigger-JavaScript/metadata.json" target="Templates/IoTHubTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/IoTHubTrigger-JavaScript/sample.dat" target="Templates/IoTHubTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/IoTHubTrigger-Custom/function.json" target="Templates/IoTHubTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/IoTHubTrigger-Custom/metadata.json" target="Templates/IoTHubTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/IoTHubTrigger-TypeScript/function.json" target="Templates/IoTHubTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/IoTHubTrigger-TypeScript/index.ts" target="Templates/IoTHubTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/IoTHubTrigger-TypeScript/metadata.json" target="Templates/IoTHubTrigger-TypeScript/metadata.json" />
@@ -200,6 +220,8 @@
     <file src="../../Functions.Templates/templates/EventGridTrigger-JavaScript/function.json" target="Templates/EventGridTrigger-JavaScript/function.json" />
     <file src="../../Functions.Templates/templates/EventGridTrigger-JavaScript/metadata.json" target="Templates/EventGridTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/EventGridTrigger-JavaScript/sample.dat" target="Templates/EventGridTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/EventGridTrigger-Custom/function.json" target="Templates/EventGridTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/EventGridTrigger-Custom/metadata.json" target="Templates/EventGridTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/EventGridTrigger-TypeScript/index.ts" target="Templates/EventGridTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/EventGridTrigger-TypeScript/function.json" target="Templates/EventGridTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/EventGridTrigger-TypeScript/metadata.json" target="Templates/EventGridTrigger-TypeScript/metadata.json" />
@@ -271,6 +293,8 @@
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/function.json" />
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/metadata.json" />
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" target="Templates/SignalRConnectionInfoHttpTrigger-JavaScript/sample.dat" />
+    <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json" />
+    <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json" />
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" target="Templates/SignalRConnectionInfoHttpTrigger-TypeScript/metadata.json" />

--- a/Functions.Templates/Templates/BlobTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/BlobTrigger-Custom/function.json
@@ -1,0 +1,11 @@
+{
+    "bindings": [
+        {
+            "name": "myBlob",
+            "type": "blobTrigger",
+            "direction": "in",
+            "path": "samples-workitems/{name}",
+            "connection":""
+        }
+    ]
+}

--- a/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
@@ -1,0 +1,21 @@
+{
+    "defaultFunctionName": "BlobTrigger",
+    "description": "$BlobTrigger_description",
+    "name": "Azure Blob Storage trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "blob",
+    "enabledInTryMode": true,
+    "userPrompt": [
+        "connection",
+        "path"
+    ],
+    "extensions": [
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+      }
+    ]
+  }

--- a/Functions.Templates/Templates/CosmosDBTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-Custom/function.json
@@ -1,0 +1,14 @@
+{
+  "bindings": [
+    {
+      "type": "cosmosDBTrigger",
+      "name": "documents",
+      "direction": "in",
+      "leaseCollectionName": "leases",
+      "connectionStringSetting": "",
+      "databaseName": "",
+      "collectionName": "",
+      "createLeaseCollectionIfNotExists" : true
+    }
+  ]
+}

--- a/Functions.Templates/Templates/CosmosDBTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-Custom/metadata.json
@@ -1,0 +1,24 @@
+{
+  "defaultFunctionName": "CosmosTrigger",
+  "description": "$CosmosDBTrigger_description",
+  "name": "Azure Cosmos DB trigger",
+  "language": "Custom",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_dataProcessing"
+  ],
+  "categoryStyle": "cosmosDB",
+  "enabledInTryMode": false,
+  "userPrompt": [
+    "connectionStringSetting",
+    "databaseName",
+    "collectionName",
+    "leaseCollectionName",
+    "createLeaseCollectionIfNotExists"
+  ],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/EventGridTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/EventGridTrigger-Custom/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "type": "eventGridTrigger",
+      "name": "eventGridEvent",
+      "direction": "in"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/EventGridTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/EventGridTrigger-Custom/metadata.json
@@ -1,0 +1,18 @@
+{
+    "defaultFunctionName": "EventGridTrigger",
+    "description": "$EventGridTrigger_description",
+    "name": "Azure Event Grid trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "eventGrid",
+    "enabledInTryMode": false,
+    "userPrompt": [],
+    "extensions": [
+        {
+            "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid", "version": "2.1.0"
+        }
+    ]
+}

--- a/Functions.Templates/Templates/EventHubTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Custom/function.json
@@ -1,0 +1,13 @@
+{
+    "bindings": [
+      {
+        "type": "eventHubTrigger",
+        "name": "eventHubMessages",
+        "direction": "in",
+        "eventHubName": "samples-workitems",
+        "connection": "",
+        "cardinality": "many",
+        "consumerGroup": "$Default"
+      }
+    ]
+}

--- a/Functions.Templates/Templates/EventHubTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Custom/metadata.json
@@ -1,0 +1,22 @@
+{
+  "defaultFunctionName": "EventHubTrigger",
+  "description": "$EventHubTrigger_description",
+  "name": "Azure Event Hub trigger",
+  "language": "Custom",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_dataProcessing"
+  ],
+  "categoryStyle": "eventHub",
+  "enabledInTryMode": false,
+  "userPrompt": [
+    "connection",
+    "eventHubName",
+    "consumerGroup"
+  ],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/HttpTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/HttpTrigger-Custom/function.json
@@ -1,0 +1,19 @@
+{
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "get",
+                "post"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "res"
+        }
+    ]
+}

--- a/Functions.Templates/Templates/HttpTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/HttpTrigger-Custom/metadata.json
@@ -1,0 +1,16 @@
+{
+    "defaultFunctionName": "HttpTrigger",
+    "description": "$HttpTrigger_description",
+    "name": "HTTP trigger",
+    "trigger": "HttpTrigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_api"
+    ],
+    "categoryStyle": "http",
+    "enabledInTryMode": false,
+    "userPrompt": [
+        "authLevel"
+    ]
+}

--- a/Functions.Templates/Templates/IoTHubTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-Custom/function.json
@@ -1,0 +1,13 @@
+{
+    "bindings": [
+      {
+        "type": "eventHubTrigger",
+        "name": "IoTHubMessages",
+        "direction": "in",
+        "eventHubName": "samples-workitems",
+        "connection": "",
+        "cardinality": "many",
+        "consumerGroup": "$Default"
+      }
+    ]
+}

--- a/Functions.Templates/Templates/IoTHubTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-Custom/metadata.json
@@ -1,0 +1,21 @@
+{
+  "defaultFunctionName": "IoTHub_EventHub",
+  "description": "$IoTHubTrigger_description",
+  "name": "IoT Hub (Event Hub)",
+  "language": "Custom",
+  "category": [
+    "$temp_category_IoTHub"
+  ],
+  "categoryStyle": "iot",
+  "enabledInTryMode": false,
+  "userPrompt": [
+    "connection",
+    "path",
+    "consumerGroup"
+  ],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/QueueTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/QueueTrigger-Custom/function.json
@@ -1,0 +1,11 @@
+{
+    "bindings": [
+        {
+            "name": "myQueueItem",
+            "type": "queueTrigger",
+            "direction": "in",
+            "queueName": "js-queue-items",
+            "connection":""
+        }
+    ]
+}

--- a/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
@@ -1,0 +1,21 @@
+{
+    "defaultFunctionName": "QueueTrigger",
+    "description": "$QueueTrigger_description",
+    "name": "Azure Queue Storage trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "queue",
+    "enabledInTryMode": true,
+    "userPrompt": [
+        "connection",
+        "queueName"
+    ],
+    "extensions": [
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+      }
+    ]
+  }

--- a/Functions.Templates/Templates/SendGrid-Custom/function.json
+++ b/Functions.Templates/Templates/SendGrid-Custom/function.json
@@ -1,0 +1,20 @@
+{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "apiKey": "SendGridApiKey",
+            "from": "Azure Functions <samples@functions.com>",
+            "to": "{customerEmail}",
+            "subject": "",
+            "text": ""
+        }
+    ]
+}

--- a/Functions.Templates/Templates/SendGrid-Custom/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-Custom/metadata.json
@@ -1,0 +1,27 @@
+{
+    "defaultFunctionName": "SendGrid",
+    "description": "$SendGrid_description",
+    "name": "SendGrid",
+    "language": "Custom",
+    "category": [
+        "$temp_category_samples",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "other",
+    "enabledInTryMode": false,
+    "userPrompt": [
+        "to",
+        "from",
+        "subject",
+        "text",
+        "apiKey"
+    ],
+    "extensions": [
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+      }
+    ]
+}

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/function.json
@@ -1,0 +1,11 @@
+{
+    "bindings": [
+        {
+            "name": "mySbMsg",
+            "type": "serviceBusTrigger",
+            "direction": "in",
+            "queueName": "myinputqueue",
+            "connection": ""
+        }
+    ]
+}

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/metadata.json
@@ -1,0 +1,21 @@
+{
+    "defaultFunctionName": "ServiceBusQueueTrigger",
+    "description": "$ServiceBusQueueTrigger_description",
+    "name": "Azure Service Bus Queue trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "serviceBus",
+    "enabledInTryMode": false,
+    "userPrompt": [
+        "connection",
+        "queueName"
+    ],
+    "extensions": [
+        {
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+        }
+    ]
+}

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/function.json
@@ -1,0 +1,12 @@
+{
+    "bindings": [
+        {
+            "name": "mySbMsg",
+            "type": "serviceBusTrigger",
+            "direction": "in",
+            "topicName": "mytopic",
+            "subscriptionName": "mysubscription",
+            "connection": ""
+        }
+    ]
+}

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/metadata.json
@@ -1,0 +1,22 @@
+{
+    "defaultFunctionName": "ServiceBusTopicTrigger",
+    "description": "$ServiceBusTopicTrigger_description",
+    "name": "Azure Service Bus Topic trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    "categoryStyle": "serviceBus",
+    "enabledInTryMode": false,
+    "userPrompt": [
+        "connection",
+        "topicName",
+        "subscriptionName"
+    ],
+    "extensions": [
+        {
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+        }
+    ]
+}

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-Custom/function.json
@@ -1,0 +1,27 @@
+{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": [
+        "post"
+      ],
+      "name": "req",
+      "route": "negotiate"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    },
+    {
+      "type": "signalRConnectionInfo",
+      "name": "connectionInfo",
+      "hubName": "default",
+      "connectionStringSetting": "AzureSignalRConnectionString",
+      "direction": "in"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-Custom/metadata.json
@@ -1,0 +1,22 @@
+{
+  "defaultFunctionName": "negotiate",
+  "description": "$signalRConnectionInfoNegotiate_description",
+  "name": "SignalR negotiate HTTP trigger",
+  "language": "Custom",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_api"
+  ],
+  "categoryStyle": "other",
+  "enabledInTryMode": false,
+  "userPrompt": [
+    "hubName",
+    "connectionStringSetting",
+    "route"
+  ],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService", "version": "1.0.2"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/TimerTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/TimerTrigger-Custom/function.json
@@ -1,0 +1,10 @@
+{
+    "bindings": [
+        {
+            "name": "myTimer",
+            "type": "timerTrigger",
+            "direction": "in",
+            "schedule": "0 */5 * * * *"
+        }
+    ]
+}

--- a/Functions.Templates/Templates/TimerTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/TimerTrigger-Custom/metadata.json
@@ -1,0 +1,16 @@
+{
+    "defaultFunctionName": "TimerTrigger",
+    "description": "$TimerTrigger_description",
+    "name": "Timer trigger",
+    "language": "Custom",
+    "category": [
+        "$temp_category_core",
+        "$temp_category_dataProcessing"
+    ],
+    
+  "categoryStyle": "timer",
+    "enabledInTryMode": true,
+    "userPrompt": [
+        "schedule"
+    ]
+}


### PR DESCRIPTION
Purely because core-tools v3.x has a dependency on 3.x versions
https://github.com/Azure/azure-functions-core-tools/blob/v3.x/build/Settings.cs