### PR TITLE
Fixed the parameter name for Python event hubs template

### DIFF
--- a/Functions.Templates/Templates/EventHubTrigger-Python/function.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Python/function.json
@@ -3,7 +3,7 @@
     "bindings": [
       {
         "type": "eventHubTrigger",
-        "name": "event",
+        "name": "events",
         "direction": "in",
         "eventHubName": "samples-workitems",
         "connection": "",


### PR DESCRIPTION
Fix for #971.

The `__init__.py` file has a parameter called `events`, but the `function.json` file named the parameter `event`. This fixes the name in the json.