### PR TITLE
Adding entity label to Resources.resx

### DIFF
--- a/Functions.Templates/Resources/Resources.resx
+++ b/Functions.Templates/Resources/Resources.resx
@@ -1828,4 +1828,7 @@ function app.</value>
   <data name="entityTrigger_name_label" xml:space="preserve">
     <value>Entity Name</value>
   </data>
+  <data name="entityTrigger_activity_label" xml:space="preserve">
+    <value>Entity name</value>
+  </data>
 </root>


### PR DESCRIPTION
Adding `entityTrigger_activity_label` to Resources.resx to make it consistent with bindings.json.