### PR TITLE
Updating DurableTask version to 2.3.1

### DIFF
--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -1161,7 +1161,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\entityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
       },
       "settings": [
         {
@@ -1220,7 +1220,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-PowerShell-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-PowerShell-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntity-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntity-JavaScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntity-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntity-TypeScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityClass-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityClass-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityFunction-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityFunction-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-CSharp-2.x/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-JavaScript/metadata.json
@@ -13,7 +13,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttpStart-TypeScript/metadata.json
@@ -15,7 +15,7 @@
   "extensions": [
     {
       "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-      "version": "2.3.0"
+      "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-PowerShell-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-PowerShell-2.x/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-2.x/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-PowerShell-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-PowerShell-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-2.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-2.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.3.1"
     }
   ]
 }


### PR DESCRIPTION
Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` version from `2.3.0` to `2.3.1`.