### PR TITLE
Fixed gulp-build error due to faulty path in nuspec file

### DIFF
--- a/Build/PackageFiles/ExtensionBundleTemplates-2.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundleTemplates-2.x.nuspec
@@ -181,9 +181,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsEntity-TypeScript/index.ts" target="Templates/DurableFunctionsEntity-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/DurableFunctionsEntity-TypeScript/function.json" target="Templates/DurableFunctionsEntity-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsEntity-TypeScript/metadata.json" target="Templates/DurableFunctionsEntity-TypeScript/metadata.json" />
-    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python/__init__.py" target="Templates/DurableFunctionsEntity-Python/__init__.py" />
-    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python/function.json" target="Templates/DurableFunctionsEntity-Python/function.json" />
-    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python/metadata.json" target="Templates/DurableFunctionsEntity-Python/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python-2.x/__init__.py" target="Templates/DurableFunctionsEntity-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python-2.x/function.json" target="Templates/DurableFunctionsEntity-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsEntity-Python-2.x/metadata.json" target="Templates/DurableFunctionsEntity-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/SendGrid-CSharp/function.json" target="templates/SendGrid-CSharp/function.json" />
     <file src="../../Functions.Templates/templates/SendGrid-CSharp/metadata.json" target="templates/SendGrid-CSharp/metadata.json" />
     <file src="../../Functions.Templates/templates/SendGrid-CSharp/SendGridCSharp.csx" target="templates/SendGrid-CSharp/run.csx" />


### PR DESCRIPTION
Somehow the CI did not catch this while merging my previous PR, but apparently there was a missing `-2.x` suffix in the nuspec file for Durable Functions Python