### PR TITLE
Updated durable functions templates in C# to use nameof 

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/DurableFunctionsEntityHttpCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/DurableFunctionsEntityHttpCSharp.cs
@@ -16,7 +16,7 @@ namespace Company.Function
         [DurableClient] IDurableEntityClient client,
         string entityKey)
         {
-            var entityId = new EntityId("Counter", entityKey);
+            var entityId = new EntityId(nameof(Counter), entityKey);
 
             if (req.Method == HttpMethod.Post)
             {
@@ -28,7 +28,7 @@ namespace Company.Function
             return req.CreateResponse(HttpStatusCode.OK, stateResponse.EntityState);
         }
 
-        [FunctionName("Counter")]
+        [FunctionName(nameof(Counter))]
         public static void Counter([EntityTrigger] IDurableEntityContext context)
         {
             switch (context.OperationName.ToLowerInvariant())

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/DurableFunctionsOrchestrationCSharp.cs
@@ -17,15 +17,15 @@ namespace Company.Function
             var outputs = new List<string>();
 
             // Replace "hello" with the name of your Durable Activity Function.
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "Tokyo"));
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "Seattle"));
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "London"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
 
             // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
             return outputs;
         }
 
-        [FunctionName("DurableFunctionsOrchestrationCSharp_Hello")]
+        [FunctionName(nameof(SayHello))]
         public static string SayHello([ActivityTrigger] string name, ILogger log)
         {
             log.LogInformation($"Saying hello to {name}.");

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/DurableFunctionsOrchestrationCSharp.cs
@@ -18,15 +18,15 @@ namespace Company.Function
             var outputs = new List<string>();
 
             // Replace "hello" with the name of your Durable Activity Function.
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "Tokyo"));
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "Seattle"));
-            outputs.Add(await context.CallActivityAsync<string>("DurableFunctionsOrchestrationCSharp_Hello", "London"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
 
             // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
             return outputs;
         }
 
-        [FunctionName("DurableFunctionsOrchestrationCSharp_Hello")]
+        [FunctionName(nameof(SayHello))]
         public static string SayHello([ActivityTrigger] string name, ILogger log)
         {
             log.LogInformation($"Saying hello to {name}.");


### PR DESCRIPTION
This uses nameof wherever possible instead of magic strings. This makes navigating to the symbols (F12 in Visual Studio) much easier and more convenient. It also avoids errors when renaming a method.