### PR TITLE
Add Python Durable templates back

### DIFF
--- a/Build/PackageFiles/ExtensionBundleTemplates-1.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundleTemplates-1.x.nuspec
@@ -143,6 +143,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/function.json" target="Templates/DurableFunctionsActivity-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsActivity-PowerShell/run.ps1" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/metadata.json" target="Templates/DurableFunctionsActivity-PowerShell/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/function.json" target="Templates/DurableFunctionsActivity-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/__init__.py" target="templates/DurableFunctionsActivity-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/metadata.json" target="Templates/DurableFunctionsActivity-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/function.json" target="Templates/DurableFunctionsActivity-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/index.ts" target="templates/DurableFunctionsActivity-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/metadata.json" target="Templates/DurableFunctionsActivity-TypeScript/metadata.json" />
@@ -155,6 +158,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/function.json" target="Templates/DurableFunctionsOrchestrator-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsOrchestrator-PowerShell/run.ps1" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/metadata.json" target="Templates/DurableFunctionsOrchestrator-PowerShell/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/function.json" target="Templates/DurableFunctionsOrchestrator-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/__init__.py" target="templates/DurableFunctionsOrchestrator-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json" target="Templates/DurableFunctionsOrchestrator-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/function.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/index.ts" target="templates/DurableFunctionsOrchestrator-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" />
@@ -167,6 +173,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/function.json" target="templates/DurableFunctionsHttpStart-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsHttpStart-PowerShell/run.ps1" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/metadata.json" target="templates/DurableFunctionsHttpStart-PowerShell/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/function.json" target="Templates/DurableFunctionsHttpStart-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/__init__.py" target="templates/DurableFunctionsHttpStart-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/metadata.json" target="Templates/DurableFunctionsHttpStart-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/function.json" target="templates/DurableFunctionsHttpStart-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/metadata.json" target="templates/DurableFunctionsHttpStart-TypeScript/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/index.ts" target="templates/DurableFunctionsHttpStart-TypeScript/index.ts" />    

--- a/Build/PackageFiles/Templates.nuspec
+++ b/Build/PackageFiles/Templates.nuspec
@@ -143,6 +143,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/function.json" target="Templates/DurableFunctionsActivity-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsActivity-PowerShell/run.ps1" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-PowerShell-1.x/metadata.json" target="Templates/DurableFunctionsActivity-PowerShell/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/function.json" target="Templates/DurableFunctionsActivity-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/__init__.py" target="templates/DurableFunctionsActivity-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsActivity-Python-1.x/metadata.json" target="Templates/DurableFunctionsActivity-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/function.json" target="Templates/DurableFunctionsActivity-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/index.ts" target="templates/DurableFunctionsActivity-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/DurableFunctionsActivity-TypeScript/metadata.json" target="Templates/DurableFunctionsActivity-TypeScript/metadata.json" />
@@ -155,6 +158,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/function.json" target="Templates/DurableFunctionsOrchestrator-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsOrchestrator-PowerShell/run.ps1" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-PowerShell-1.x/metadata.json" target="Templates/DurableFunctionsOrchestrator-PowerShell/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/function.json" target="Templates/DurableFunctionsOrchestrator-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/__init__.py" target="templates/DurableFunctionsOrchestrator-Python/__init__.py" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json" target="Templates/DurableFunctionsOrchestrator-Python/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/function.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/index.ts" target="templates/DurableFunctionsOrchestrator-TypeScript/index.ts" />
     <file src="../../Functions.Templates/templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" target="Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json" />
@@ -167,6 +173,9 @@
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/function.json" target="templates/DurableFunctionsHttpStart-PowerShell/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/metadata.json" target="templates/DurableFunctionsHttpStart-PowerShell/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-PowerShell-1.x/run.ps1" target="templates/DurableFunctionsHttpStart-PowerShell/run.ps1" />    
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/function.json" target="templates/DurableFunctionsHttpStart-Python/function.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/metadata.json" target="templates/DurableFunctionsHttpStart-Python/metadata.json" />
+    <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-Python-1.x/__init__.py" target="templates/DurableFunctionsHttpStart-Python/__init__.py" />    
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/function.json" target="templates/DurableFunctionsHttpStart-TypeScript/function.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/metadata.json" target="templates/DurableFunctionsHttpStart-TypeScript/metadata.json" />
     <file src="../../Functions.Templates/templates/DurableFunctionsHttpStart-TypeScript/index.ts" target="templates/DurableFunctionsHttpStart-TypeScript/index.ts" />

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/__init__.py
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/__init__.py
@@ -1,0 +1,13 @@
+# This function is not intended to be invoked directly. Instead it will be
+# triggered by an orchestrator function.
+# Before running this sample, please:
+# - create a Durable orchestration function
+# - create a Durable HTTP starter function
+# - add azure-functions-durable to requirements.txt
+# - run pip install -r requirements.txt
+
+import logging
+
+
+def main(name: str) -> str:
+    return f"Hello {name}!"

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/function.json
@@ -1,0 +1,10 @@
+﻿{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
@@ -1,7 +1,7 @@
 ﻿{
   "defaultFunctionName": "Hello",
   "description": "$DurableFunctionsActivity_description",
-  "name": "Durable Functions activity (upgrade to bundles V2)",
+  "name": "Durable Functions activity",
   "language": "Python",
   "category": [
     "$temp_category_core",

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
@@ -1,0 +1,18 @@
+﻿{
+  "defaultFunctionName": "Hello",
+  "description": "$DurableFunctionsActivity_description",
+  "name": "Durable Functions activity (upgrade to bundles V2)",
+  "language": "Python",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_durableFunctions"
+  ],
+  "categoryStyle": "other",
+  "enabledInTryMode": false,
+  "userPrompt": [],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-Python-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.6"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/__init__.py
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/__init__.py
@@ -1,0 +1,20 @@
+# This function an HTTP starter function for Durable Functions.
+# Before running this sample, please:
+# - create a Durable orchestration function
+# - create a Durable activity function (default name is "Hello")
+# - add azure-functions-durable to requirements.txt
+# - run pip install -r requirements.txt
+ 
+import logging
+
+import azure.functions as func
+import azure.durable_functions as df
+
+
+async def main(req: func.HttpRequest, starter: str) -> func.HttpResponse:
+    client = df.DurableOrchestrationClient(starter)
+    instance_id = await client.start_new(req.route_params["functionName"], None, None)
+
+    logging.info(f"Started orchestration with ID = '{instance_id}'.")
+
+    return client.create_check_status_response(req, instance_id)

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/function.json
@@ -1,0 +1,26 @@
+﻿{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "req",
+      "type": "httpTrigger",
+      "direction": "in",
+      "route": "orchestrators/{functionName}",
+      "methods": [
+        "post",
+        "get"
+      ]
+    },
+    {
+      "name": "$return",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.6"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
@@ -1,7 +1,7 @@
 ﻿{
   "defaultFunctionName": "DurableFunctionsHttpStart",
   "description": "$DurableFunctionsHttpStart_description",
-  "name": "Durable Functions HTTP starter (upgrade to bundles V2)",
+  "name": "Durable Functions HTTP starter",
   "language": "Python",
   "category": [
     "$temp_category_core",

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/metadata.json
@@ -1,0 +1,20 @@
+﻿{
+  "defaultFunctionName": "DurableFunctionsHttpStart",
+  "description": "$DurableFunctionsHttpStart_description",
+  "name": "Durable Functions HTTP starter (upgrade to bundles V2)",
+  "language": "Python",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_durableFunctions"
+  ],
+  "categoryStyle": "other",
+  "enabledInTryMode": false,
+  "userPrompt": [
+    "authLevel"
+  ],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/__init__.py
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/__init__.py
@@ -1,0 +1,22 @@
+# This function is not intended to be invoked directly. Instead it will be
+# triggered by an HTTP starter function.
+# Before running this sample, please:
+# - create a Durable activity function (default name is "Hello")
+# - create a Durable HTTP starter function
+# - add azure-functions-durable to requirements.txt
+# - run pip install -r requirements.txt
+
+import logging
+import json
+
+import azure.functions as func
+import azure.durable_functions as df
+
+
+def orchestrator_function(context: df.DurableOrchestrationContext):
+    result1 = yield context.call_activity('Hello', "Tokyo")
+    result2 = yield context.call_activity('Hello', "Seattle")
+    result3 = yield context.call_activity('Hello', "London")
+    return [result1, result2, result3]
+
+main = df.Orchestrator.create(orchestrator_function)

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
@@ -1,0 +1,10 @@
+﻿{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
@@ -3,7 +3,7 @@
   "bindings": [
     {
       "name": "context",
-      "type": "orchestrationTrigger",
+      "type": "orchestrationClient",
       "direction": "in"
     }
   ]

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
@@ -1,0 +1,18 @@
+﻿{
+  "defaultFunctionName": "DurableFunctionsOrchestrator",
+  "description": "$DurableFunctionsOrchestrator_description",
+  "name": "Durable Functions orchestrator (upgrade to bundles V2)",
+  "language": "Python",
+  "category": [
+    "$temp_category_core",
+    "$temp_category_durableFunctions"
+  ],
+  "categoryStyle": "other",
+  "enabledInTryMode": false,
+  "userPrompt": [],
+  "extensions": [
+    {
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+    }
+  ]
+}

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
@@ -1,7 +1,7 @@
 ﻿{
   "defaultFunctionName": "DurableFunctionsOrchestrator",
   "description": "$DurableFunctionsOrchestrator_description",
-  "name": "Durable Functions orchestrator (upgrade to bundles V2)",
+  "name": "Durable Functions orchestrator",
   "language": "Python",
   "category": [
     "$temp_category_core",

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.4.0"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.6"
     }
   ]
 }


### PR DESCRIPTION
Since the VSCode plugin defaults to bundles V1 at project creation time, removing the Durable Python templates caused users not to be able to scaffold Durable Python projects. This PR adds the templates back.