### PR TITLE
Use safer binding names for Durable Python in V1

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-Python-1.x/function.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "starter",
-      "type": "durableClient",
+      "type": "orchestrationClient",
       "direction": "in"
     }
   ]

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-Python-1.x/function.json
@@ -3,7 +3,7 @@
   "bindings": [
     {
       "name": "context",
-      "type": "orchestrationClient",
+      "type": "orchestrationTrigger",
       "direction": "in"
     }
   ]


### PR DESCRIPTION
This PR removes and fixes incorrect template binding names in V1 for Durable Python.