### PR TITLE
Update TimerTrigger Readme

### DIFF
--- a/Functions.Templates/Templates/TimerTrigger-PowerShell/readme.md
+++ b/Functions.Templates/Templates/TimerTrigger-PowerShell/readme.md
@@ -4,7 +4,7 @@ The `TimerTrigger` makes it incredibly easy to have your functions executed on a
 
 ## How it works
 
-For a `TimerTrigger` to work, you provide a schedule in the form of a [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression)(See the link for full details). A cron expression is a string with 6 separate expressions which represent a given schedule via patterns. The pattern we use to represent every 5 minutes is `0 */5 * * * *`. This, in plain text, means: "When seconds is equal to 0, minutes is divisible by 5, for any hour, day of the month, month, day of the week, or year".
+For a `TimerTrigger` to work, you provide a schedule in the form of a [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression)(See the link for full details). A cron expression is a string with 6 separate expressions which represent a given schedule via patterns. The pattern we use to represent every 5 minutes is `0 */5 * * * *`. This, in plain text, means: "When seconds is equal to 0, minutes is divisible by 5, for any hour, day of the month, month, and day of the week".
 
 ## Learn more
 


### PR DESCRIPTION
Azure Functions cron expressions don't express year.  The 6th value is for day of the week.  This same change needs to happen in all the other language readme files.