### PR TITLE
[v2.x] Update Kafka Extension related %Password% AppSettings 

### DIFF
--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -209,7 +209,7 @@
         {
           "name": "password",
           "value": "string",
-          "defaultValue": "%EventHubsConnectionString%",           
+          "defaultValue": "%KafkaPassword%",           
           "resource": "AppSetting",
           "required": false,
           "label": "$kafka_password_label",
@@ -337,7 +337,7 @@
         {
           "name": "password",
           "value": "string",
-          "defaultValue": "%EventHubsConnectionString%",           
+          "defaultValue": "%KafkaPassword%",           
           "resource": "AppSetting",
           "required": false,
           "label": "$kafka_password_label",

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -164,7 +164,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\kafkaTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2"
       },
       "settings": [
         {
@@ -292,7 +292,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\kafkaOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2"
       },
       "settings": [
         {

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -209,7 +209,7 @@
         {
           "name": "password",
           "value": "string",
-          "defaultValue": "%Password%",           
+          "defaultValue": "%EventHubsConnectionString%",           
           "resource": "AppSetting",
           "required": false,
           "label": "$kafka_password_label",
@@ -337,7 +337,7 @@
         {
           "name": "password",
           "value": "string",
-          "defaultValue": "%Password%",           
+          "defaultValue": "%EventHubsConnectionString%",           
           "resource": "AppSetting",
           "required": false,
           "label": "$kafka_password_label",

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
@@ -115,7 +115,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
@@ -41,8 +41,8 @@
         "Password": {
             "description": "SASL password for use with the PLAIN and SASL_SCRAM",
             "type": "parameter",
-            "defaultValue": "%Password%",
-            "replaces": "%Password%"
+            "defaultValue": "%EventHubsConnectionString%",
+            "replaces": "%EventHubsConnectionString%"
         },
         "Protocol": {
             "description": "Security protocol used to communicate with brokers",

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
@@ -41,8 +41,8 @@
         "Password": {
             "description": "SASL password for use with the PLAIN and SASL_SCRAM",
             "type": "parameter",
-            "defaultValue": "%EventHubsConnectionString%",
-            "replaces": "%EventHubsConnectionString%"
+            "defaultValue": "%KafkaPassword%",
+            "replaces": "%KafkaPassword%"
         },
         "Protocol": {
             "description": "Security protocol used to communicate with brokers",

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
@@ -18,7 +18,7 @@ namespace Company.Function
             [Kafka("BrokerList",
                    "topic",
                    Username = "$ConnectionString",
-                   Password = "%EventHubsConnectionString%",
+                   Password = "%KafkaPassword%",
                    Protocol = BrokerProtocol.SaslSsl,
                    AuthenticationMode = BrokerAuthenticationMode.Plain
             )] out string eventData,

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
@@ -18,7 +18,7 @@ namespace Company.Function
             [Kafka("BrokerList",
                    "topic",
                    Username = "$ConnectionString",
-                   Password = "%Password%",
+                   Password = "%EventHubsConnectionString%",
                    Protocol = BrokerProtocol.SaslSsl,
                    AuthenticationMode = BrokerAuthenticationMode.Plain
             )] out string eventData,

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/function.json
@@ -21,7 +21,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain"
         }

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/function.json
@@ -21,7 +21,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain"
         }

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/metadata.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/metadata.json
@@ -19,7 +19,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2"
       }
     ]
   }

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-JavaScript/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-JavaScript/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%Password%",
+            "password" : "%EventHubsConnectionString%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-JavaScript/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-JavaScript/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%EventHubsConnectionString%",
+            "password" : "%KafkaPassword%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-JavaScript/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-JavaScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-JavaScript/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-JavaScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-PowerShell/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-PowerShell/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%Password%",
+            "password" : "%EventHubsConnectionString%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-PowerShell/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-PowerShell/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%EventHubsConnectionString%",
+            "password" : "%KafkaPassword%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-PowerShell/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-PowerShell/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-PowerShell/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-PowerShell/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-Python/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-Python/function.json
@@ -18,7 +18,7 @@
         "brokerList" : "BrokerList",
         "topic" : "topic",
         "username" : "$ConnectionString",
-        "password" : "%Password%",
+        "password" : "%EventHubsConnectionString%",
         "protocol" : "SASLSSL",
         "authenticationMode" : "PLAIN"
       },

--- a/Functions.Templates/Templates/KafkaOutput-Python/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-Python/function.json
@@ -18,7 +18,7 @@
         "brokerList" : "BrokerList",
         "topic" : "topic",
         "username" : "$ConnectionString",
-        "password" : "%EventHubsConnectionString%",
+        "password" : "%KafkaPassword%",
         "protocol" : "SASLSSL",
         "authenticationMode" : "PLAIN"
       },

--- a/Functions.Templates/Templates/KafkaOutput-Python/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-Python/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-Python/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-Python/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-TypeScript/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-TypeScript/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%Password%",
+            "password" : "%EventHubsConnectionString%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-TypeScript/function.json
+++ b/Functions.Templates/Templates/KafkaOutput-TypeScript/function.json
@@ -16,7 +16,7 @@
             "brokerList" : "BrokerList",
             "topic" : "topic",
             "username" : "$ConnectionString",
-            "password" : "%EventHubsConnectionString%",
+            "password" : "%KafkaPassword%",
             "protocol" : "SASLSSL",
             "authenticationMode" : "PLAIN",
             "direction": "out"

--- a/Functions.Templates/Templates/KafkaOutput-TypeScript/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-TypeScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaOutput-TypeScript/readme.md
+++ b/Functions.Templates/Templates/KafkaOutput-TypeScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaOutput` to work, you must provide a topic name which dictates where 
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
@@ -41,8 +41,8 @@
         "Password": {
             "description": "SASL password for use with the PLAIN and SASL_SCRAM",
             "type": "parameter",
-            "defaultValue": "%Password%",
-            "replaces": "%Password%"
+            "defaultValue": "%EventHubsConnectionString%",
+            "replaces": "%EventHubsConnectionString%"
         },
         "Protocol": {
             "description": "Security protocol used to communicate with brokers",

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
@@ -41,8 +41,8 @@
         "Password": {
             "description": "SASL password for use with the PLAIN and SASL_SCRAM",
             "type": "parameter",
-            "defaultValue": "%EventHubsConnectionString%",
-            "replaces": "%EventHubsConnectionString%"
+            "defaultValue": "%KafkaPassword%",
+            "replaces": "%KafkaPassword%"
         },
         "Protocol": {
             "description": "Security protocol used to communicate with brokers",

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/.template.config/template.json
@@ -121,7 +121,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/KafkaTriggerCSharp.cs
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/KafkaTriggerCSharp.cs
@@ -8,16 +8,16 @@ namespace Company.Function
     {
         // KafkaTrigger sample 
         // Consume the message from "topic" on the LocalBroker.
-        // Add `BrokerList` and `EventHubsConnectionString` to the local.settings.json
+        // Add `BrokerList` and `KafkaPassword` to the local.settings.json
         // For EventHubs
         // "BrokerList": "{EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093"
-        // "EventHubsConnectionString":"{EVENT_HUBS_CONNECTION_STRING}
+        // "KafkaPassword":"{EVENT_HUBS_CONNECTION_STRING}
         [FunctionName("KafkaTriggerCSharp")]
         public static void Run(
             [KafkaTrigger("BrokerList",
                           "topic",
                           Username = "$ConnectionString",
-                          Password = "%EventHubsConnectionString%",
+                          Password = "%KafkaPassword%",
                           Protocol = BrokerProtocol.SaslSsl,
                           AuthenticationMode = BrokerAuthenticationMode.Plain,
                           ConsumerGroup = "$Default")] KafkaEventData<string>[] events, ILogger log)

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/KafkaTriggerCSharp.cs
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/KafkaTriggerCSharp.cs
@@ -8,16 +8,16 @@ namespace Company.Function
     {
         // KafkaTrigger sample 
         // Consume the message from "topic" on the LocalBroker.
-        // Add `BrokerList` and `Password` to the local.settings.json
+        // Add `BrokerList` and `EventHubsConnectionString` to the local.settings.json
         // For EventHubs
         // "BrokerList": "{EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093"
-        // "Password":"{EVENT_HUBS_CONNECTION_STRING}
+        // "EventHubsConnectionString":"{EVENT_HUBS_CONNECTION_STRING}
         [FunctionName("KafkaTriggerCSharp")]
         public static void Run(
             [KafkaTrigger("BrokerList",
                           "topic",
                           Username = "$ConnectionString",
-                          Password = "%Password%",
+                          Password = "%EventHubsConnectionString%",
                           Protocol = BrokerProtocol.SaslSsl,
                           AuthenticationMode = BrokerAuthenticationMode.Plain,
                           ConsumerGroup = "$Default")] KafkaEventData<string>[] events, ILogger log)

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/metadata.json
@@ -20,7 +20,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.2.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Kafka", "version": "3.3.2"
       }
     ]
   }

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-CSharp/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-CSharp/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-Custom/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"         

--- a/Functions.Templates/Templates/KafkaTrigger-Custom/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-Custom/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"         

--- a/Functions.Templates/Templates/KafkaTrigger-JavaScript/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-JavaScript/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default",

--- a/Functions.Templates/Templates/KafkaTrigger-JavaScript/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-JavaScript/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default",

--- a/Functions.Templates/Templates/KafkaTrigger-JavaScript/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-JavaScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-JavaScript/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-JavaScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-PowerShell/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-PowerShell/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-PowerShell/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-PowerShell/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-PowerShell/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-PowerShell/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -22,7 +22,7 @@ _local.settings.json_
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-PowerShell/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-PowerShell/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -22,7 +22,7 @@ _local.settings.json_
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-Python/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-Python/function.json
@@ -8,7 +8,7 @@
           "brokerList": "BrokerList",
           "topic": "topic",
           "username": "$ConnectionString",
-          "password": "%Password%",
+          "password": "%EventHubsConnectionString%",
           "protocol": "saslSsl",
           "authenticationMode": "plain",
           "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-Python/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-Python/function.json
@@ -8,7 +8,7 @@
           "brokerList": "BrokerList",
           "topic": "topic",
           "username": "$ConnectionString",
-          "password": "%EventHubsConnectionString%",
+          "password": "%KafkaPassword%",
           "protocol": "saslSsl",
           "authenticationMode": "plain",
           "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-Python/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-Python/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-Python/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-Python/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-TypeScript/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-TypeScript/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%Password%",
+            "password": "%EventHubsConnectionString%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-TypeScript/function.json
+++ b/Functions.Templates/Templates/KafkaTrigger-TypeScript/function.json
@@ -7,7 +7,7 @@
             "brokerList": "BrokerList",
             "topic": "topic",
             "username": "$ConnectionString",
-            "password": "%EventHubsConnectionString%",
+            "password": "%KafkaPassword%",
             "protocol": "saslSsl",
             "authenticationMode": "plain",
             "consumerGroup": "$Default"

--- a/Functions.Templates/Templates/KafkaTrigger-TypeScript/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-TypeScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
+Add `BrokerList` and `KafkaPassword` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
+    "KafkaPassword": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```

--- a/Functions.Templates/Templates/KafkaTrigger-TypeScript/readme.md
+++ b/Functions.Templates/Templates/KafkaTrigger-TypeScript/readme.md
@@ -10,7 +10,7 @@ For a `KafkaTrigger` to work, you must provide a topic name which dictates where
 
 ### EventHubs for Kafka
 
-Add `BrokerList` and `Password` to your `local.settings.json`
+Add `BrokerList` and `EventHubsConnectionString` to your `local.settings.json`
 
 _local.settings.json_
 
@@ -21,7 +21,7 @@ _local.settings.json_
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "BrokerList": "{YOUR_EVENT_HUBS_NAMESPACE}.servicebus.windows.net:9093",
-    "Password": "{EVENT_HUBS_CONNECTION_STRING}"
+    "EventHubsConnectionString": "{EVENT_HUBS_CONNECTION_STRING}"
   }
 }
 ```


### PR DESCRIPTION
I create the Kafka extension template, however, the template include an issue. 
We use `%Password%` to set the password, and fetch it from AppSettings, however, it doesn't work on Azure. 
Probably, it is reserved word. 

I switch it into `%EventHubsConnectionString%` since the broker template is written for EventHubs Kafka API. 
I'll Create v3 PR as well. 

CC: @pragnagopa 