### PR TITLE
Added IsNullOrEmpty to check blank Query Parameter

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-CSharp/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp/HttpTriggerCSharp.cs
@@ -23,7 +23,7 @@ namespace Company.Function
 
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
             dynamic data = JsonConvert.DeserializeObject(requestBody);
-            name = name ?? data?.name;
+            name = !string.IsNullOrEmpty(name) ? name : data?.name
 
             string responseMessage = string.IsNullOrEmpty(name)
                 ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."

--- a/Functions.Templates/Templates/HttpTrigger-CSharp/HttpTriggerCSharp.csx
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp/HttpTriggerCSharp.csx
@@ -13,7 +13,7 @@ public static async Task<IActionResult> Run(HttpRequest req, ILogger log)
 
     string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
     dynamic data = JsonConvert.DeserializeObject(requestBody);
-    name = name ?? data?.name;
+    name = !string.IsNullOrEmpty(name) ? name : data?.name;
 
     string responseMessage = string.IsNullOrEmpty(name)
         ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."


### PR DESCRIPTION
Added IsNullOrEmpty condition to avoid skipping body elements due to a blank parameter. 
Feel free to deny if you believe the body element should not be taken into consideration if the URL parameter key is present with a blank value.