### PR TITLE
Updating Functions V4 item templates to use newest extension packages

### DIFF
--- a/FallBackFolderBuild/extensions.json
+++ b/FallBackFolderBuild/extensions.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "name": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "3.2.0"

--- a/FallBackFolderBuild/extensions.json
+++ b/FallBackFolderBuild/extensions.json
@@ -1,12 +1,12 @@
 [
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "name": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
     },
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "3.2.0"
+        "name": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
     },
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "3.0.6"
+        "name": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
@@ -15,13 +15,13 @@
         "name": "Microsoft.Azure.WebJobs.Extensions.MicrosoftGraph", "version": "1.0.0-beta6"
     },
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.3"
+        "name": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.EventGrid", "version": "2.1.0"
     },
     {
-        "name": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+        "name": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     },
     {
         "name": "Microsoft.Azure.WebJobs.Extensions.Twilio", "version": "3.0.0"

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -73,7 +73,7 @@
       ],
       "documentation": "$content=Documentation\\queueOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -122,7 +122,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\rabbitMQTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.0.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.1.0"
       },
       "settings": [
         {
@@ -412,7 +412,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\queueTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -471,7 +471,7 @@
       ],
       "documentation": "$content=Documentation\\blobOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -520,7 +520,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\blobIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -569,7 +569,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\blobTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -770,7 +770,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\serviceBusTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "3.2.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
       },
       "settings": [
         {
@@ -879,7 +879,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\serviceBusOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "3.2.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
       },
       "settings": [
         {
@@ -972,7 +972,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\tableOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -1021,7 +1021,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\tableIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       },
       "settings": [
         {
@@ -1099,7 +1099,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\eventHubTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "3.0.6"
+        "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
       },
       "settings": [
         {
@@ -1210,7 +1210,7 @@
         }
       ],
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "3.0.6"
+        "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
       },
       "documentation": "$content=Documentation\\eventHubOut.md",
       "settings": [
@@ -1385,7 +1385,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.3"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
       },
       "settings": [
         {
@@ -1418,7 +1418,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.3"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
       },
       "settings": [
         {
@@ -1451,7 +1451,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.3"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
       },
       "settings": [
         {
@@ -1529,7 +1529,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\cosmosDBTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
       },
       "settings": [
         {
@@ -1595,7 +1595,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\documentDBOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
       },
       "settings": [
         {
@@ -1668,7 +1668,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\documentDBIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
       },
       "settings": [
         {

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -73,7 +73,7 @@
       ],
       "documentation": "$content=Documentation\\queueOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -412,7 +412,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\queueTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -471,7 +471,7 @@
       ],
       "documentation": "$content=Documentation\\blobOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -520,7 +520,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\blobIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -569,7 +569,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\blobTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -972,7 +972,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\tableOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {
@@ -1021,7 +1021,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\tableIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/BlobTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/BlobTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/BlobTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+      "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
     }
   ]
 }

--- a/Functions.Templates/Templates/BlobTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+      "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
     }
   ]
 }

--- a/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-FSharp/.template.config/template.json
@@ -45,7 +45,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5",
             "projectFileExtensions": ".fsproj"
           }
         },

--- a/Functions.Templates/Templates/BlobTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-FSharp/.template.config/template.json
@@ -45,7 +45,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
             "projectFileExtensions": ".fsproj"
           }
         },

--- a/Functions.Templates/Templates/BlobTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-FSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-          "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+          "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
         }
     ]
 }

--- a/Functions.Templates/Templates/BlobTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-FSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-          "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+          "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
         }
     ]
 }

--- a/Functions.Templates/Templates/BlobTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-Python/metadata.json
@@ -18,7 +18,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-Python/metadata.json
@@ -18,7 +18,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/BlobTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/BlobTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp/.template.config/template.json
@@ -53,7 +53,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ]
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-Custom/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ]
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-FSharp/.template.config/template.json
@@ -51,7 +51,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/CosmosDBTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-FSharp/metadata.json
@@ -18,7 +18,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+        "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
       }
     ]
   }

--- a/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ]
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-PowerShell/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ]
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-Python/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ],
   "filters": [

--- a/Functions.Templates/Templates/CosmosDBTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-TypeScript/metadata.json
@@ -18,7 +18,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.5"
+      "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB", "version": "3.0.10"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-JavaScript/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsActivity-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsActivity-TypeScript/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-CSharp-1.x/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-JavaScript/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsHttpStart-TypeScript/metadata.json
@@ -14,7 +14,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
@@ -34,7 +34,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
@@ -34,7 +34,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-1.x/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-CSharp-1.x/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-JavaScript/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
@@ -12,7 +12,7 @@
   "userPrompt": [],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "1.8.7"
+      "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.5.1"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Custom/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-JavaScript/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-PowerShell/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Python/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/EventHubTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/EventHubTrigger-TypeScript/metadata.json
@@ -16,7 +16,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IoTHubTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IoTHubTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IoTHubTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IoTHubTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IoTHubTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/IoTHubTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
   ],
   "extensions": [
     {
-      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1"
+      "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0"
     }
   ]
 }

--- a/Functions.Templates/Templates/IotHubTrigger-CSharpVS/.template.config/template.json
+++ b/Functions.Templates/Templates/IotHubTrigger-CSharpVS/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.1.1",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "4.2.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/QueueTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/QueueTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/QueueTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-FSharp/.template.config/template.json
@@ -45,7 +45,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5",
             "projectFileExtensions": ".fsproj"
           }
         },

--- a/Functions.Templates/Templates/QueueTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-FSharp/.template.config/template.json
@@ -45,7 +45,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
             "projectFileExtensions": ".fsproj"
           }
         },

--- a/Functions.Templates/Templates/QueueTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-FSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-FSharp/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-FSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-Python/metadata.json
@@ -18,7 +18,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-Python/metadata.json
@@ -18,7 +18,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
   }

--- a/Functions.Templates/Templates/QueueTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/QueueTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
   }

--- a/Functions.Templates/Templates/RabbitMQTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/RabbitMQTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.0.0",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.1.0",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/RabbitMQTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/RabbitMQTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.0.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "version": "1.1.0"
       }
     ]
   }

--- a/Functions.Templates/Templates/SendGrid-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SendGrid-CSharp/.template.config/template.json
@@ -70,7 +70,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/SendGrid-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SendGrid-CSharp/.template.config/template.json
@@ -70,7 +70,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/SendGrid-CSharp/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-CSharp/metadata.json
@@ -19,7 +19,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-CSharp/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-CSharp/metadata.json
@@ -19,7 +19,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-Custom/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-Custom/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-Custom/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-Custom/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-JavaScript/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-JavaScript/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-PowerShell/metadata.json
@@ -21,7 +21,7 @@
             "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
         },
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+            "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
         }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-PowerShell/metadata.json
@@ -21,7 +21,7 @@
             "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
         },
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+            "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
         }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-TypeScript/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "3.0.10"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
       }
     ]
 }

--- a/Functions.Templates/Templates/SendGrid-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/SendGrid-TypeScript/metadata.json
@@ -21,7 +21,7 @@
         "id": "Microsoft.Azure.WebJobs.Extensions.SendGrid", "version": "3.0.0"
       },
       {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.4"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Storage", "version": "4.0.5"
       }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp/.template.config/template.json
@@ -48,7 +48,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0",
+                "reference": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-Custom/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-JavaScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-PowerShell/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-Python/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-TypeScript/metadata.json
@@ -15,7 +15,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/.template.config/template.json
@@ -54,7 +54,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0",
+                "reference": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-Custom/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-JavaScript/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-JavaScript/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-PowerShell/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-PowerShell/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-Python/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-Python/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-TypeScript/metadata.json
@@ -16,7 +16,7 @@
     ],
     "extensions": [
         {
-            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.1.0"
+            "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "version": "4.3.0"
         }
     ]
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-templates/issues/1097 
Spec - https://github.com/Azure/Azure-Functions/issues/1987

Details of the versions upgraded -
Microsoft.Azure.WebJobs.Extensions.Storage | 4.0.5
Microsoft.Azure.WebJobs.Extensions.ServiceBus | 4.3.0
Microsoft.Azure.WebJobs.Extensions.EventHubs | 4.2.0
Microsoft.Azure.WebJobs.Extensions.DurableTask | 2.5.1
Microsoft.Azure.WebJobs.Extensions.CosmosDB | 3.0.10
Microsoft.Azure.WebJobs.Extensions.EventGrid | 2.1.0
Microsoft.Azure.WebJobs.Extensions.RabbitMQ | 1.1.0
Microsoft.Azure.WebJobs.Extensions.Kafka | 3.3.2

