### PR TITLE
Ignore Azurite Files in Function App

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/_gitignore
+++ b/Functions.Templates/ProjectTemplate/CSharp/_gitignore
@@ -262,3 +262,8 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json

--- a/Functions.Templates/ProjectTemplate/FSharp/_gitignore
+++ b/Functions.Templates/ProjectTemplate/FSharp/_gitignore
@@ -262,3 +262,8 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json


### PR DESCRIPTION
When using the Azurite Extension in Visual Studio Code (<https://marketplace.visualstudio.com/items?itemName=Azurite.azurite>) several files get created by this extension in the Azure Functions project directory that are only relevant for local development. In analogy to e.g. `local.settings.json` they should be ignored by git by default and therefore be part of the standard `.gitignore` template.

This pull request contains the proposed changes for the C# and F# template (see also merged pull request for VS Code Azure Functions extension <https://github.com/microsoft/vscode-azurefunctions/pull/2972>) 