### PR TITLE
Updating worker packages to latest versions in dotnet isolated template

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/Company.FunctionApp.csproj
@@ -6,8 +6,8 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.2.0" OutputItemType="Analyzer"/>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.5.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Updating worker packages to latest versions in dotnet isolated template.

- [Microsoft.Azure.Functions.Worker](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker/) : 1.5.2 to 1.6.0
- [Microsoft.Azure.Functions.Worker.Sdk](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Sdk/) : 1.2.0 to 1.3.0

These versions now match with what is in [v4 branch](https://github.com/Azure/azure-functions-templates/blob/v4.x/Functions.Templates/ProjectTemplate/CSharp-Isolated/Company.FunctionApp.csproj#L9).
