### PR TITLE
Update isolated worker template to default to V4 host

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/template.json
@@ -26,7 +26,7 @@
         "AzureFunctionsVersion": {
             "description": "The setting that determines the target release",
             "type": "parameter",
-            "defaultValue": "V3",
+            "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
         }
     },


### PR DESCRIPTION
Because the project file has `net6.0` hard-coded into, and V3 + net6 don't go well together.