### PR TITLE
Updated for global usings

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/GlobalUsings.cs
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using global::Microsoft.Azure.Functions.Worker;
+global using global::Microsoft.Azure.Functions.Worker.Http;
+global using global::Microsoft.Extensions.Hosting;
+global using global::Microsoft.Extensions.Logging;
+global using global::System.Net;

--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/GlobalUsings.cs
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/GlobalUsings.cs
@@ -1,5 +1,5 @@
-global using global::Microsoft.Azure.Functions.Worker;
-global using global::Microsoft.Azure.Functions.Worker.Http;
-global using global::Microsoft.Extensions.Hosting;
-global using global::Microsoft.Extensions.Logging;
-global using global::System.Net;
+global using Microsoft.Azure.Functions.Worker;
+global using Microsoft.Azure.Functions.Worker.Http;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
+global using System.Net;

--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/.template.config/template.json
@@ -26,7 +26,7 @@
         "AzureFunctionsVersion": {
             "description": "The setting that determines the target release",
             "type": "parameter",
-            "defaultValue": "V3",
+            "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
         }
     },

--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/Company.FunctionApp.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>AzureFunctionsVersionValue</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>    
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
@@ -17,5 +19,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
   </ItemGroup>
 </Project>

--- a/Functions.Templates/ProjectTemplate/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate/CSharp-Isolated/Program.cs
@@ -1,19 +1,5 @@
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Azure.Functions.Worker.Configuration;
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .Build();
 
-namespace Company.FunctionApp
-{
-    public class Program
-    {
-        public static void Main()
-        {
-            var host = new HostBuilder()
-                .ConfigureFunctionsWorkerDefaults()
-                .Build();
-
-            host.Run();
-        }
-    }
-}
+host.Run();


### PR DESCRIPTION
We'd want to move global usings to Azure SDK when possible, but this would get it started. I looked at updating item templates, but that would break existing projects.

Includes fix from PR #1145

@jamesmontemagno