### PR TITLE
Update version for the OpenAPI extension (v4.x)

### DIFF
--- a/Functions.Templates/Templates/HttpTriggerWithOpenAPI-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTriggerWithOpenAPI-CSharp/.template.config/template.json
@@ -65,7 +65,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.WebJobs.Extensions.OpenApi",
-                "version": "0.7.2-preview",
+                "version": "1.0.0",
                 "projectFileExtensions": ".csproj"
             }
         },


### PR DESCRIPTION
This PR is to update the OpenAPI extension version from `0.7.2-preview` to `1.0.0` which was GA in November, 2021, for the v4.x runtime.