### PR TITLE
Update DurableTask Extension version to 2.6.1 (v3.x)

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
@@ -34,7 +34,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.6.0",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "2.6.1",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
As in title, part of our release process in: https://github.com/Azure/azure-functions-durable-extension/issues/2064