### PR TITLE
Updating In-proc .csproj to use Microsoft.NET.Sdk.Functions 4.1.0

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Updating in-proc project template to use the [4.1.0 version of Microsoft.NET.Sdk.Functions](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/4.1.0). This version inclues the fix for the below issue.

[Binding metrics not emitted for in-proc precompiled applications](https://github.com/Azure/azure-functions-host/issues/8059)