### PR TITLE
Changing to windows-latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ trigger:
     - master
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-latest'
 
 variables:
   devops_buildNumber: $[counter(format(''), 1500)]


### PR DESCRIPTION
Per [this announcement](https://github.com/actions/virtual-environments/issues/4312), `vs2017-win2016` is deprecated. This PR will update the VM Image for `azure-pipelines.yml`