### PR TITLE
Add Framework parameter to project templates

### DIFF
--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/.template.config/template.json
@@ -28,6 +28,21 @@
             "type": "parameter",
             "defaultValue": "V3",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "choices": [
+                {
+                  "choice": "net5.0",
+                  "description": "Target net5.0",
+                  "displayName": ".NET 5.0"
+                }
+            ],
+            "replaces": "net5.0",
+            "defaultValue": "net5.0",
+            "displayName": "Framework"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/template.json
@@ -28,6 +28,21 @@
             "type": "parameter",
             "defaultValue": "V3",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "choices": [
+                {
+                  "choice": "netcoreapp3.1",
+                  "description": "Target netcoreapp3.1",
+                  "displayName": ".NET Core 3.1"
+                }
+            ],
+            "replaces": "netcoreapp3.1",
+            "defaultValue": "netcoreapp3.1",
+            "displayName": "Framework"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v3.x/FSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/FSharp/.template.config/template.json
@@ -22,6 +22,21 @@
         "defaultValue": "UseDevelopmentStorage=True",
         "replaces": "AzureWebJobsStorageConnectionStringValue",
         "DataType": "AzureStorage"
+      },
+      "Framework": {
+        "type": "parameter",
+        "description": "The target framework for the project.",
+        "datatype": "choice",
+        "choices": [
+          {
+            "choice": "netcoreapp3.1",
+            "description": "Target netcoreapp3.1",
+            "displayName": ".NET Core 3.1"
+          }
+        ],
+        "replaces": "netcoreapp3.1",
+        "defaultValue": "netcoreapp3.1",
+        "displayName": "Framework"
       }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -28,6 +28,21 @@
             "type": "parameter",
             "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "choices": [
+                {
+                  "choice": "net6.0",
+                  "description": "Target net6.0",
+                  "displayName": ".NET 6.0"
+                }
+            ],
+            "replaces": "net6.0",
+            "defaultValue": "net6.0",
+            "displayName": "Framework"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
@@ -28,6 +28,21 @@
             "type": "parameter",
             "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "choices": [
+                {
+                  "choice": "net6.0",
+                  "description": "Target net6.0",
+                  "displayName": ".NET 6.0"
+                }
+            ],
+            "replaces": "net6.0",
+            "defaultValue": "net6.0",
+            "displayName": "Framework"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -28,6 +28,21 @@
             "type": "parameter",
             "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "choices": [
+                {
+                  "choice": "net6.0",
+                  "description": "Target net6.0",
+                  "displayName": ".NET 6.0"
+                }
+            ],
+            "replaces": "net6.0",
+            "defaultValue": "net6.0",
+            "displayName": "Framework"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
@@ -22,6 +22,21 @@
         "defaultValue": "UseDevelopmentStorage=True",
         "replaces": "AzureWebJobsStorageConnectionStringValue",
         "DataType": "AzureStorage"
+      },
+      "Framework": {
+        "type": "parameter",
+        "description": "The target framework for the project.",
+        "datatype": "choice",
+        "choices": [
+           {
+             "choice": "net6.0",
+             "description": "Target net6.0",
+             "displayName": ".NET 6.0"
+           }
+        ],
+        "replaces": "net6.0",
+        "defaultValue": "net6.0",
+        "displayName": "Framework"
       }
     },
     "sources": [


### PR DESCRIPTION
Add `Framework` parameter to project templates. This allows overriding the target framework from the command line/template engine.