### PR TITLE
Updating Microsoft.NET.Sdk.Functions to 3.1.0 in dotnet in-proc templates

### DIFF
--- a/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate/CSharp/Company.FunctionApp.csproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate/FSharp/Company.FunctionApp.fsproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Updating `Microsoft.NET.Sdk.Functions` package version to [3.1.0](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.1.0), which has the below fix.

[V3 backport-Include all bindings when generating function metadata #542](https://github.com/Azure/azure-functions-vs-build-sdk/pull/547)