### PR TITLE
Adding default launchSetting.json for .NET Templates

### DIFF
--- a/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates-Isolated_v3.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates-Isolated_v3.x.nuspec
@@ -21,6 +21,7 @@
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Program.cs" target="content/ProjectTemplate-CSharp/Program.cs" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/host.json" target="content/ProjectTemplate-CSharp/host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/local.settings.json" target="content/ProjectTemplate-CSharp/local.settings.json" />
+    <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Properties/launchSettings.json" target="content/ProjectTemplate-CSharp/Properties/launchSettings.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/.template.config/template.json" target="content/ProjectTemplate-CSharp/.template.config/template.json" />
   </files>
 </package>

--- a/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates-Isolated_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates-Isolated_v4.x.nuspec
@@ -21,6 +21,7 @@
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs" target="content/ProjectTemplate-CSharp/Program.cs" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/host.json" target="content/ProjectTemplate-CSharp/host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/local.settings.json" target="content/ProjectTemplate-CSharp/local.settings.json" />
+    <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Properties/launchSettings.json" target="content/ProjectTemplate-CSharp/Properties/launchSettings.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json" target="content/ProjectTemplate-CSharp/.template.config/template.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/_gitignore" target="content/ProjectTemplate-FSharp/_gitignore" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj" target="content/ProjectTemplate-FSharp/Company.FunctionApp.fsproj" />

--- a/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates_v3.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates_v3.x.nuspec
@@ -20,6 +20,7 @@
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/Company.FunctionApp.csproj" target="content/ProjectTemplate-CSharp/Company.FunctionApp.csproj" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/host.json" target="content/ProjectTemplate-CSharp/host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/local.settings.json" target="content/ProjectTemplate-CSharp/local.settings.json" />
+    <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/Properties/launchSettings.json" target="content/ProjectTemplate-CSharp/Properties/launchSettings.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/template.json" target="content/ProjectTemplate-CSharp/.template.config/template.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/dotnetcli.host.json" target="content/ProjectTemplate-CSharp/.template.config/dotnetcli.host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v3.x/FSharp/_gitignore" target="content/ProjectTemplate-FSharp/_gitignore" />

--- a/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ProjectTemplates_v4.x.nuspec
@@ -20,6 +20,7 @@
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj" target="content/ProjectTemplate-CSharp/Company.FunctionApp.csproj" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/host.json" target="content/ProjectTemplate-CSharp/host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/local.settings.json" target="content/ProjectTemplate-CSharp/local.settings.json" />
+    <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/Properties/launchSettings.json" target="content/ProjectTemplate-CSharp/Properties/launchSettings.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json" target="content/ProjectTemplate-CSharp/.template.config/template.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/dotnetcli.host.json" target="content/ProjectTemplate-CSharp/.template.config/dotnetcli.host.json" />
     <file src="../../../Functions.Templates/ProjectTemplate_v4.x/FSharp/_gitignore" target="content/ProjectTemplate-FSharp/_gitignore" />

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Company.FunctionApp": {
+      "commandName": "Project",
+      "launchBrowser": false
+    }
+  }
+}

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Company.FunctionApp": {
+      "commandName": "Project",
+      "launchBrowser": false
+    }
+  }
+}

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Company.FunctionApp": {
+      "commandName": "Project",
+      "launchBrowser": false
+    }
+  }
+}

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Company.FunctionApp": {
+      "commandName": "Project",
+      "launchBrowser": false
+    }
+  }
+}


### PR DESCRIPTION
This is the first pull request to introduce launchSettings.json to Azure Functions projects. The current settings in the launchSettings does not alter any project behavior. There will be more follow-up PRs to enable the following scenarios: 

1. Ability to add a random available port to the launchSettings.json (through the port commandlineargs) so that 2 different Azure Functions projects can run simultaneously without port conflicts. We want to make it similar to how ASP.NET Core projects handle IISExpress and Kestrel ports.  
2. Ability to update the launchBrowser settings to true when a HttpTrigger item template is added. 

/cc @BillHiebert @phenning 