### PR TITLE
Automatically generate Http port for Azure Functions project

### DIFF
--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/.template.config/template.json
@@ -28,6 +28,28 @@
             "type": "parameter",
             "defaultValue": "V3",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "FunctionsHttpPort": {
+            "type": "parameter",
+            "datatype": "integer",
+            "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+        },
+        "FunctionsHttpPortGenerated": {
+            "type": "generated",
+            "generator": "port",
+            "parameters": {
+              "low": 7000,
+              "high": 7300
+            }
+        },
+        "FunctionsHttpPortReplacer": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+              "sourceVariableName": "FunctionsHttpPort",
+              "fallbackVariableName": "FunctionsHttpPortGenerated"
+            },
+            "replaces": "7071"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp-Isolated/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Company.FunctionApp": {
       "commandName": "Project",
+      "commandLineArgs": "--port 7071",
       "launchBrowser": false
     }
   }

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp/.template.config/template.json
@@ -28,6 +28,28 @@
             "type": "parameter",
             "defaultValue": "V3",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "FunctionsHttpPort": {
+            "type": "parameter",
+            "datatype": "integer",
+            "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+        },
+        "FunctionsHttpPortGenerated": {
+            "type": "generated",
+            "generator": "port",
+            "parameters": {
+              "low": 7000,
+              "high": 7300
+            }
+        },
+        "FunctionsHttpPortReplacer": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+              "sourceVariableName": "FunctionsHttpPort",
+              "fallbackVariableName": "FunctionsHttpPortGenerated"
+            },
+            "replaces": "7071"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Company.FunctionApp": {
       "commandName": "Project",
+      "commandLineArgs": "--port 7071",
       "launchBrowser": false
     }
   }

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -28,6 +28,28 @@
             "type": "parameter",
             "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "FunctionsHttpPort": {
+            "type": "parameter",
+            "datatype": "integer",
+            "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+        },
+        "FunctionsHttpPortGenerated": {
+            "type": "generated",
+            "generator": "port",
+            "parameters": {
+              "low": 7000,
+              "high": 7300
+            }
+        },
+        "FunctionsHttpPortReplacer": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+              "sourceVariableName": "FunctionsHttpPort",
+              "fallbackVariableName": "FunctionsHttpPortGenerated"
+            },
+            "replaces": "7071"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Company.FunctionApp": {
       "commandName": "Project",
+      "commandLineArgs": "--port 7071",
       "launchBrowser": false
     }
   }

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
@@ -28,6 +28,28 @@
             "type": "parameter",
             "defaultValue": "V4",
             "replaces": "AzureFunctionsVersionValue"
+        },
+        "FunctionsHttpPort": {
+            "type": "parameter",
+            "datatype": "integer",
+            "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+        },
+        "FunctionsHttpPortGenerated": {
+            "type": "generated",
+            "generator": "port",
+            "parameters": {
+              "low": 7000,
+              "high": 7300
+            }
+        },
+        "FunctionsHttpPortReplacer": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+              "sourceVariableName": "FunctionsHttpPort",
+              "fallbackVariableName": "FunctionsHttpPortGenerated"
+            },
+            "replaces": "7071"
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/Properties/launchSettings.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Company.FunctionApp": {
       "commandName": "Project",
+      "commandLineArgs": "--port 7071",
       "launchBrowser": false
     }
   }


### PR DESCRIPTION
This change is to ensure that more than one Azure functions project created from VS or the commandline can be run without any other modifications. 

With this change, every new Azure function project that gets created will be assigned an available port between 7000 & 7300. The default value for the port is 7071