### PR TITLE
Bump template id so v3 and v4 can be used with `dotnet new`

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -8,7 +8,7 @@
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",
-    "identity": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x",
+    "identity": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.4.x",
     "shortName": "func",
     "tags": {
         "language": "C#",

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
@@ -8,7 +8,7 @@
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",
-    "identity": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x",
+    "identity": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.4.x",
     "shortName": "func",
     "tags": {
         "language": "C#",

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -8,7 +8,7 @@
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",
-    "identity": "Microsoft.AzureFunctions.ProjectTemplate.FSharp.Isolated.3.x",
+    "identity": "Microsoft.AzureFunctions.ProjectTemplate.FSharp.Isolated.4.x",
     "shortName": "func",
     "tags": {
         "language": "F#",

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
@@ -8,7 +8,7 @@
     "generatorVersions": "[1.0.0.0-*)",
     "groupIdentity": "Microsoft.AzureFunctions.ProjectTemplates",
     "precedence": "100",
-    "identity": "Microsoft.AzureFunctions.ProjectTemplate.FSharp.3.x",
+    "identity": "Microsoft.AzureFunctions.ProjectTemplate.FSharp.4.x",
     "shortName": "func",
     "tags": {
         "language": "F#",


### PR DESCRIPTION
Bump template id so v3 and v4 can be used with `dotnet new`. Right now the id is the same for both v3 and v4 templates.