### PR TITLE
fix type for queueMessage

### DIFF
--- a/Functions.Templates/Templates/QueueTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates/QueueTrigger-TypeScript/index.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context } from "@azure/functions"
 
-const queueTrigger: AzureFunction = async function (context: Context, myQueueItem: string): Promise<void> {
+const queueTrigger: AzureFunction = async function (context: Context, myQueueItem: any): Promise<void> {
     context.log('Queue trigger function processed work item', myQueueItem);
 };
 


### PR DESCRIPTION
The queue message can be a string but can also be a JSON object. 

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/41597107/170366891-e3d1bf8e-51da-4100-815d-612a5562ac98.png">

@ggailey777
@soninaren 