### PR TITLE
Update Microsoft.NET.Sdk.Functions package version to 4.11(v4) & 3.11(v3) in in-proc template

### DIFF
--- a/Functions.Templates/ProjectTemplate_v3.x/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v3.x/CSharp/Company.FunctionApp.csproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v3.x/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v3.x/FSharp/Company.FunctionApp.fsproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp/Company.FunctionApp.fsproj
@@ -5,7 +5,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Update Microsoft.NET.Sdk.Functions package version to [4.11](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/4.1.1)(v4) & [3.11](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.1.1)(v3) in in-proc template