### PR TITLE
Fix incorrect case of EventBody property name in Event hub trigger boiler plate code

### DIFF
--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-5.x/EventHubTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-5.x/EventHubTriggerCSharp.cs
@@ -21,7 +21,7 @@ namespace Company.Function
                 try
                 {
                     // Replace these two lines with your processing logic.
-                    log.LogInformation($"C# Event Hub trigger function processed a message: {eventData.eventBody}");
+                    log.LogInformation($"C# Event Hub trigger function processed a message: {eventData.EventBody}");
                     await Task.Yield();
                 }
                 catch (Exception e)


### PR DESCRIPTION
Fixes #1226 

Fixing the boiler plate code for event hub trigger(inproc) where the incorrect case (camelCase) was used for the `EventBody` property name.