### PR TITLE
Microsoft.Azure.Functions.Worker version bump to 1.8.0 for dotnet-isolated 

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -23,7 +23,7 @@
 <!--#endif -->
 <!--#if (NetFramework)-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0-preview2" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -17,7 +17,7 @@
 <!--#endif -->
 <!--#if (Framework == "net7.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0-preview2" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -17,7 +17,7 @@
 <!--#endif -->
 <!--#if (Framework == "net7.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0-preview2" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 <!--#if (Framework == "net6.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" />
   </ItemGroup>
 <!--#endif -->
 <!--#if (Framework == "net7.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0-preview2" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 <!--#if (Framework == "net6.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" /> 
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 <!--#if (Framework == "net6.0")-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" /> 
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" />
   </ItemGroup>
 <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="host.json">


### PR DESCRIPTION
Bumping Microsoft.Azure.Functions.Worker to 1.8.0 for dotnet-isolated templates