### PR TITLE
Reverting Event Hub Python template to use many cardinality

### DIFF
--- a/Functions.Templates/Templates/EventHubTrigger-Python/__init__.py
+++ b/Functions.Templates/Templates/EventHubTrigger-Python/__init__.py
@@ -1,8 +1,10 @@
+from typing import List
 import logging
 
 import azure.functions as func
 
 
-def main(event: func.EventHubEvent):
-    logging.info('Python EventHub trigger processed an event: %s',
-                 event.get_body().decode('utf-8'))
+def main(events: List[func.EventHubEvent]):
+     for event in events:
+         logging.info('Python EventHub trigger processed an event: %s',
+                         event.get_body().decode('utf-8'))

--- a/Functions.Templates/Templates/EventHubTrigger-Python/function.json
+++ b/Functions.Templates/Templates/EventHubTrigger-Python/function.json
@@ -3,7 +3,7 @@
     "bindings": [
       {
         "type": "eventHubTrigger",
-        "name": "event",
+        "name": "events",
         "direction": "in",
         "eventHubName": "samples-workitems",
         "connection": "",


### PR DESCRIPTION
The event hub Python trigger was recently updated to have single cardinality, but the `cardinality` field itself was not updated, meaning creating a new event hub python trigger would lead to a functions app that would crash.

This PR reverts the single cardinality back to many, keeping this trigger in-line with the other event hub triggers. Fixes
#1250 