### PR TITLE
Update SQL Binding JS/TS instructions to change bundle preview to 4.x

### DIFF
--- a/Functions.Templates/Templates/SqlInputBinding-JavaScript/index.js
+++ b/Functions.Templates/Templates/SqlInputBinding-JavaScript/index.js
@@ -6,7 +6,7 @@
  *      1. Update "commandText" in function.json - this should be the query to execute to retrieve the values being returned
  *      2. Add an app setting named "SqlConnectionString" containing the connection string
  *          to use for the SQL connection
- *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[3.*, 4.0.0)"
+ *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[4.*, 5.0.0)"
  * @param context The Azure Function runtime context
  * @param req The HttpRequest that triggered this function
  * @param results The array of objects returned by the SQL input binding

--- a/Functions.Templates/Templates/SqlInputBinding-Typescript/index.ts
+++ b/Functions.Templates/Templates/SqlInputBinding-Typescript/index.ts
@@ -8,7 +8,7 @@ import { AzureFunction, Context, HttpRequest } from "@azure/functions"
  *      1. Update "commandText" in function.json - this should be the query to execute to retrieve the values being returned
  *      2. Add an app setting named "SqlConnectionString" containing the connection string
  *          to use for the SQL connection
- *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[3.*, 4.0.0)"
+ *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[4.*, 5.0.0)"
  * @param context The Azure Function runtime context
  * @param req The HttpRequest that triggered this function
  * @param items The array of objects returned by the SQL input binding

--- a/Functions.Templates/Templates/SqlOutputBinding-JavaScript/index.js
+++ b/Functions.Templates/Templates/SqlOutputBinding-JavaScript/index.js
@@ -6,7 +6,7 @@
  *      1. Update "commandText" in function.json - this should be the name of the table that you wish to upsert values to
  *      2. Add an app setting named "SqlConnectionString" containing the connection string
  *          to use for the SQL connection
- *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[3.*, 4.0.0)"
+ *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[4.*, 5.0.0)"
  * @param context The Azure Function runtime context
  * @param req The HttpRequest that triggered this function
  */

--- a/Functions.Templates/Templates/SqlOutputBinding-Typescript/index.ts
+++ b/Functions.Templates/Templates/SqlOutputBinding-Typescript/index.ts
@@ -8,7 +8,7 @@ import { AzureFunction, Context, HttpRequest } from "@azure/functions"
  *      1. Update "commandText" in function.json - this should be the name of the table that you wish to upsert values to
  *      2. Add an app setting named "SqlConnectionString" containing the connection string
  *          to use for the SQL connection
- *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[3.*, 4.0.0)"
+ *      3. Change the bundle name in host.json to "Microsoft.Azure.Functions.ExtensionBundle.Preview" and the version to "[4.*, 5.0.0)"
  * @param context The Azure Function runtime context
  * @param req The HttpRequest that triggered this function
  */


### PR DESCRIPTION
Based off PowerShell Templates PR:
https://github.com/Azure/azure-functions-templates/pull/1262#discussion_r992737774

Updating instructions to instruct users to use 4.x versions instead of 3.x.

Python instructions are already updated, as well as PowerShell.