### PR TITLE
Add missing C# DF Entity templates to the v3 and v4 ItemTemplate files

### DIFF
--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v3.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v3.x.nuspec
@@ -22,6 +22,9 @@
     <file src="..\..\..\Functions.Templates\Templates\BlobTrigger-CSharp-5.x\**" target="content\BlobTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\TimerTrigger-CSharp\**" target="content\TimerTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\SendGrid-CSharp-4.x\**" target="content\SendGrid-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\EventHubTrigger-CSharp-5.x\**" target="content\EventHubTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\ServiceBusQueueTrigger-CSharp\**" target="content\ServiceBusQueueTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />

--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v3.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v3.x.nuspec
@@ -22,9 +22,9 @@
     <file src="..\..\..\Functions.Templates\Templates\BlobTrigger-CSharp-5.x\**" target="content\BlobTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\TimerTrigger-CSharp\**" target="content\TimerTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsEntityHttp-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsEntityFunction-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsEntityClass-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\SendGrid-CSharp-4.x\**" target="content\SendGrid-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\EventHubTrigger-CSharp-5.x\**" target="content\EventHubTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\ServiceBusQueueTrigger-CSharp\**" target="content\ServiceBusQueueTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />

--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
@@ -22,6 +22,9 @@
     <file src="..\..\..\Functions.Templates\Templates\BlobTrigger-CSharp-5.x\**" target="content\BlobTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\TimerTrigger-CSharp\**" target="content\TimerTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\SendGrid-CSharp-4.x\**" target="content\SendGrid-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\EventHubTrigger-CSharp-5.x\**" target="content\EventHubTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\ServiceBusQueueTrigger-CSharp\**" target="content\ServiceBusQueueTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />

--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
@@ -22,9 +22,9 @@
     <file src="..\..\..\Functions.Templates\Templates\BlobTrigger-CSharp-5.x\**" target="content\BlobTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\TimerTrigger-CSharp\**" target="content\TimerTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
-    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsOrchestration-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityHttp-CSharp-2.x\**" target="content\DurableFunctionsEntityHttp-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityFunction-CSharp-2.x\**" target="content\DurableFunctionsEntityFunction-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsEntityClass-CSharp-2.x\**" target="content\DurableFunctionsEntityClass-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\SendGrid-CSharp-4.x\**" target="content\SendGrid-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\EventHubTrigger-CSharp-5.x\**" target="content\EventHubTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\ServiceBusQueueTrigger-CSharp\**" target="content\ServiceBusQueueTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />


### PR DESCRIPTION
We recently learned that none of our Entity templates for C# are showing up in VSCode, in any of the template categories.
I **suspect** this is because those templates were not listed in the `ItemTemplates` files in this repo, which would have been an oversight.

@soninaren: can you please confirm that this theory makes sense?
Additionally, I noticed that these files are under a directory called "Dotnet_precompiled". What does the "precompiled" mean in this context?