### PR TITLE
Bump Event Grid extension version

### DIFF
--- a/Functions.Templates/Templates/EventGridTrigger-CSharp-3.x/.template.config/template.json
+++ b/Functions.Templates/Templates/EventGridTrigger-CSharp-3.x/.template.config/template.json
@@ -35,7 +35,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.WebJobs.Extensions.EventGrid", "version": "3.0.0-beta.3",
+                "reference": "Microsoft.Azure.WebJobs.Extensions.EventGrid", "version": "3.2.1",
                 "projectFileExtensions": ".csproj"
             }
         },


### PR DESCRIPTION
CloudEvent handshake support was added in 3.2.0. Updating the version here will allows CloudEvent schema event grid subscriptions to be used for new EG functions created in the portal.