### PR TITLE
[Event Hubs Extension] Bump package version

### DIFF
--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-5.x/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-5.x/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "5.3.0",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "5.4.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/.template.config/template.json
@@ -51,7 +51,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "4.3.0",
+        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "5.3.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "4.3.0",
+        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "5.3.0",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
@@ -47,7 +47,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "4.2.0",
+        "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs", "version": "4.3.0",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp/.template.config/template.json
@@ -51,7 +51,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "5.3.0",
+        "reference": "Microsoft.Azure.WebJobs.Extensions.EventHubs", "version": "5.4.0",
         "projectFileExtensions": ".fsproj"
       }
     },


### PR DESCRIPTION
The focus of these changes is to bump the Event Hubs extension package version for v5-based templates.