### PR TITLE
Fix default function name for DurableFunctionsOrchestrator-TypeScript

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestrator-TypeScript/metadata.json
@@ -1,5 +1,5 @@
 ﻿{
-  "defaultFunctionName": "DurableFunctionsOrchestratorJS",
+  "defaultFunctionName": "DurableFunctionsOrchestratorTS",
   "description": "$DurableFunctionsOrchestrator_description",
   "name": "Durable Functions orchestrator",
   "language": "TypeScript",


### PR DESCRIPTION
The default name wasn't changed from JS.