### PR TITLE
fix sqltrigger typo and add sqltrigger to extensionbundle templates 4.x

### DIFF
--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_v4.x.nuspec
@@ -106,6 +106,9 @@
     <file src="..\..\..\Functions.Templates\Templates\KustoOutputBinding-CSharp-Isolated\.template.config\vs-2017.3\*.*" target="content\KustoOutputBinding-CSharp-Isolated\.template.config\vs-2017.3" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-Isolated\DurableFunctionsOrchestrationCSharp.cs" target="content\DurableFunctionsOrchestration-CSharp\DurableFunctionsOrchestrationCSharp.cs" />
     <file src="..\..\..\Functions.Templates\Templates\DurableFunctionsOrchestration-CSharp-Isolated\.template.config\**" target="content\DurableFunctionsOrchestration-CSharp\.template.config" />
+    <file src="..\..\..\Functions.Templates\Templates\SqlTrigger-CSharp-Isolated\SqlTriggerBindingCSharp.cs" target="content\SqlTrigger-CSharp-Isolated\SqlTriggerBindingCSharp.cs" />
+    <file src="..\..\..\Functions.Templates\Templates\SqlTrigger-CSharp-Isolated\.template.config\template.json" target="content\SqlTrigger-CSharp-Isolated\.template.config\template.json" />
+    <file src="..\..\..\Functions.Templates\Templates\SqlTrigger-CSharp-Isolated\.template.config\vs-2017.3.host.json" target="content\SqlTrigger-CSharp-Isolated\.template.config\vs-2017.3.host.json" />
     <file src="..\..\..\Functions.Templates\Templates\SqlTrigger-CSharp-Isolated\.template.config\vs-2017.3\*.*" target="content\SqlTrigger-CSharp-Isolated\.template.config\vs-2017.3" />
   </files>
 </package>

--- a/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-4.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-4.x.nuspec
@@ -165,5 +165,11 @@
     <file src="..\..\..\Functions.Templates\templates\SqlOutputBinding-JavaScript\**" target="templates\SqlOutputBinding-JavaScript" />
     <file src="..\..\..\Functions.Templates\templates\SqlInputBinding-PowerShell\**" target="Templates\SqlInputBinding-PowerShell" />
     <file src="..\..\..\Functions.Templates\templates\SqlOutputBinding-PowerShell\**" target="Templates\SqlOutputBinding-PowerShell" />
+
+    <file src="..\..\..\Functions.Templates\templates\SqlTrigger-CSharp\*.*" target="Templates\SqlTrigger-CSharp" exclude="**\*.cs" />
+    <file src="..\..\..\Functions.Templates\templates\SqlTrigger-Python\**" target="Templates\SqlTrigger-Python" />
+    <file src="..\..\..\Functions.Templates\templates\SqlTrigger-Typescript\**" target="Templates\SqlTrigger-Typescript" />
+    <file src="..\..\..\Functions.Templates\templates\SqlTrigger-JavaScript\**" target="templates\SqlTrigger-JavaScript" />
+    <file src="..\..\..\Functions.Templates\templates\SqlTrigger-PowerShell\**" target="Templates\SqlTrigger-PowerShell" />
   </files>
 </package>

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function
 {
-    public static class SqlInputBindingHttpTriggerCSharp
+    public class SqlInputBindingHttpTriggerCSharp
     {
         private readonly ILogger _logger;
 
@@ -17,11 +17,10 @@ namespace Company.Function
         }
 
         [Function("SqlInputBindingHttpTriggerCSharp")]
-        public static IEnumerable<Object> Run(
+        public IEnumerable<Object> Run(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
             [SqlInput("SELECT * FROM object",
-            "SqlConnectionString",
-            CommandType = System.Data.CommandType.Text)] IEnumerable<Object> result)
+            "SqlConnectionString")] IEnumerable<Object> result)
         {
             _logger.LogInformation("C# HTTP trigger with SQL Input Binding function processed a request.");
 

--- a/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function
 {
-    public static class SqlOutputBindingHttpTriggerCSharp
+    public class SqlOutputBindingHttpTriggerCSharp
     {
         private readonly ILogger _logger;
 
@@ -19,7 +19,7 @@ namespace Company.Function
         // Visit https://aka.ms/sqlbindingsoutput to learn how to use this output binding
         [Function("SqlOutputBindingHttpTriggerCSharp")]
         [SqlOutput("table", "SqlConnectionString")]
-        public static async Task<ToDoItem> Run(
+        public async Task<ToDoItem> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
         {
             _logger.LogInformation("C# HTTP trigger with SQL Output Binding function processed a request.");

--- a/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/.template.config/template.json
@@ -8,7 +8,7 @@
     "name": "SqlTriggerBindingIsolated",
     "identity": "Azure.Function.CSharp.Isolated.SqlTriggerBinding",
     "groupIdentity": "Azure.Function.SqlTriggerBindingIsolated",
-    "shortName": "sqltigger",
+    "shortName": "sqltrigger",
     "tags": {
         "language": "C#",
         "type": "item"
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql", "version": "3.0.343-preview",
+            "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql", "version": "3.0.396",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
@@ -3,10 +3,11 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Sql;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Company.Function
 {
-    public static class SqlTriggerBindingCSharp
+    public class SqlTriggerBindingCSharp
     {
         private readonly ILogger _logger;
 
@@ -17,7 +18,7 @@ namespace Company.Function
 
         // Visit https://aka.ms/sqltrigger to learn how to use this trigger binding
         [Function("SqlTriggerBindingCSharp")]
-        public static void Run(
+        public void Run(
             [SqlTrigger("table", "SqlConnectionString")] IReadOnlyList<SqlChange<ToDoItem>> changes,
                 FunctionContext context)
         {


### PR DESCRIPTION
While testing the isolated .net 7 issue, I realized we missed adding isolated templates for sql trigger.
-  Fix typo on json
- Add SqlTrigger templates to ExtensionBundle 4.x and to ItemTemplate-Isolated 4.x