### PR TITLE
Renamed schedule to timer_trigger for py functions

### DIFF
--- a/Docs/Actions/ReplaceTokensInText.md
+++ b/Docs/Actions/ReplaceTokensInText.md
@@ -142,7 +142,7 @@ $(TIMER_FUNCTION_BODY)
 
 ```python
 @app.function_name(name="$(FUNCTION_NAME_INPUT)")
-@app.schedule(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(

--- a/Docs/Actions/ShowMarkdownPreview.md
+++ b/Docs/Actions/ShowMarkdownPreview.md
@@ -115,7 +115,7 @@ The following example template defines a job which appends the text of a file to
 
 ```python
 @app.function_name(name="$(FUNCTION_NAME_INPUT)")
-@app.schedule(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(
@@ -157,7 +157,7 @@ import azure.functions as func
 app = func.FunctionApp()
 
 @app.function_name(name="mytimer")
-@app.schedule(schedule="0 */5 * * * *", arg_name="mytimer", run_on_startup=True,
+@app.timer_trigger(schedule="0 */5 * * * *", arg_name="mytimer", run_on_startup=False,
               use_monitor=False) 
 def test_function(mytimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(

--- a/Docs/Actions/appendToFile.md
+++ b/Docs/Actions/appendToFile.md
@@ -120,7 +120,7 @@ the file at `$(SELECTED_FILEPATH)` will be replaced with their associated values
 
 ```python
 @app.function_name(name="$(FUNCTION_NAME_INPUT)")
-@app.schedule(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/blueprint_body.py
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/blueprint_body.py
@@ -1,5 +1,5 @@
 
-@$(BLUEPRINT_FILENAME).timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@$(BLUEPRINT_FILENAME).timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     if myTimer.past_due:

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/function_app.py
@@ -3,7 +3,7 @@ import azure.functions as func
 
 app = func.FunctionApp()
 
-@app.schedule(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     if myTimer.past_due:

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/function_body.py
@@ -1,4 +1,4 @@
-@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=True,
+@app.timer_trigger(schedule="$(SCHEDULE_INPUT)", arg_name="myTimer", run_on_startup=False,
               use_monitor=False) 
 def $(FUNCTION_NAME_INPUT)(myTimer: func.TimerRequest) -> None:
     

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/timer_trigger_template.md
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/timer_trigger_template.md
@@ -18,7 +18,7 @@ import azure.functions as func
 app = func.FunctionApp()
 
 @app.function_name(name="mytimer")
-@app.schedule(schedule="0 */5 * * * *", arg_name="mytimer", run_on_startup=True,
+@app.timer_trigger(schedule="0 */5 * * * *", arg_name="mytimer", run_on_startup=False,
               use_monitor=False) 
 def test_function(mytimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(


### PR DESCRIPTION
Updated timer trigger functions for python v2.
timer_trigger is the new alias for schedule for v2 timer trigger templates


the runOnStartup property for timer triggers determines whether the function should run immediately when the function app starts, rather than waiting for the scheduled time. By default, this property is set to false. There are several reasons for this default setting:

- Timer functions are typically used for scheduled tasks based on a specific timetable (e.g., every hour, daily, etc.). Setting runOnStartup to false ensures that the function runs according to its defined schedule, maintaining the predictability of executions.

- If runOnStartup were true by default, every time the function app restarts (which can happen for various reasons like deployments, platform scaling, etc.), the timer-triggered function would execute. 


- Azure Functions can be dynamically scaled, and new instances can be started based on demand. With runOnStartup set to false, new instances won't immediately execute timer-triggered functions


