### PR TITLE
Upgrading DNI http trigger templates to use Worker.Extensions.Http package version 3.1.0

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -60,7 +60,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-              "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.0.13",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.1.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/HttpTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-FSharp-Isolated/.template.config/template.json
@@ -54,7 +54,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-              "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.0.13",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.1.0",
                 "projectFileExtensions": ".csproj"
             }
         },


### PR DESCRIPTION
Upgrading DNI http trigger templates to use[ Microsoft.Azure.Functions.Worker.Extensions.Http](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Http) package version 3.1.0 which is the latest as of today.