### PR TITLE
Switch any to Timer type

### DIFF
--- a/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context } from "@azure/functions"
 
-const timerTrigger: AzureFunction = async function (context: Context, myTimer: any): Promise<void> {
+const timerTrigger: AzureFunction = async function (context: Context, myTimer: Timer): Promise<void> {
     var timeStamp = new Date().toISOString();
     
     if (myTimer.isPastDue)

--- a/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates/TimerTrigger-TypeScript/index.ts
@@ -1,4 +1,4 @@
-import { AzureFunction, Context } from "@azure/functions"
+import { AzureFunction, Context, Timer } from "@azure/functions"
 
 const timerTrigger: AzureFunction = async function (context: Context, myTimer: Timer): Promise<void> {
     var timeStamp = new Date().toISOString();


### PR DESCRIPTION
This PR addresses this issue: https://github.com/Azure/azure-functions-nodejs-library/issues/63.

A customer asked us to update the function signature for Timer triggers to use a `Timer` type instead of `any`.

Duplicate of #1488.