### PR TITLE
Updating dependency versions for .NET Isolated projects 

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -13,10 +13,10 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
@@ -11,10 +11,10 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="host.json">

--- a/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/.template.config/template.json
@@ -52,7 +52,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs",
-                "version": "6.2.0",
+                "version": "6.3.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/BlobTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/BlobTrigger-FSharp-Isolated/.template.config/template.json
@@ -46,7 +46,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs",
-                "version": "6.2.0",
+                "version": "6.3.0",
                 "projectFileExtensions": ".fsproj"
             }
         },

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/.template.config/template.json
@@ -58,7 +58,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.CosmosDB",
-        "version": "4.5.0",
+        "version": "4.6.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/CosmosDBTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-FSharp-Isolated/.template.config/template.json
@@ -52,7 +52,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.CosmosDB",
-        "version": "4.5.0",
+        "version": "4.6.0",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/.template.config/template.json
@@ -52,7 +52,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs",
-        "version": "6.0.1",
+        "version": "6.1.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/EventHubTrigger-FSharp-Isolated/.template.config/template.json
@@ -48,7 +48,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.EventHubs",
-        "version": "6.0.1",
+        "version": "6.1.0",
         "projectFileExtensions": ".fsproj"
       }
     },

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
@@ -71,7 +71,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.2.0",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.2.1",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -76,7 +76,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.2.0",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.2.1",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/.template.config/template.json
@@ -52,7 +52,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues",
-                "version": "5.2.0",
+                "version": "5.3.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/QueueTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/QueueTrigger-FSharp-Isolated/.template.config/template.json
@@ -46,7 +46,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues",
-                "version": "5.2.0",
+                "version": "5.3.0",
                 "projectFileExtensions": ".fsproj"
             }
         },

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/.template.config/template.json
@@ -53,7 +53,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus",
-                "version": "5.15.0",
+                "version": "5.16.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/.template.config/template.json
@@ -59,7 +59,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus",
-                "version": "5.15.0",
+                "version": "5.16.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -67,7 +67,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http",
-        "version": "3.0.12",
+        "version": "3.1.0",
         "projectFileExtensions": ".csproj"
       }
     },
@@ -79,7 +79,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.SignalRService",
-        "version": "1.2.2",
+        "version": "1.13.0",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
Moving package references to latest versions.

Extension packages referenced:

- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker/1.21.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.CosmosDB/4.6.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.EventHubs/6.1.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore/1.2.1
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.ServiceBus/5.16.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.SignalRService/1.13.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs/6.3.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues/5.3.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage/6.3.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Tables/1.3.0
- [x] https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.ApplicationInsights/1.2.0
