### PR TITLE
Updating Microsoft.Azure.Functions.Worker.Sdk to 1.17.0 in dni templates

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -14,7 +14,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Updating Microsoft.Azure.Functions.Worker.Sdk to 1.17.0 in dotnet isolated templates.

https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/sdk-1.17.0
