### PR TITLE
Patch .NET isolated DF templates

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
@@ -38,7 +38,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask", "version": "1.0.0",
+        "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask", "version": "1.1.1",
         "projectFileExtensions": ".csproj"
       }
     },
@@ -49,7 +49,7 @@
       "ManualInstructions": [],
       "args": {
         "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.0.13",
+        "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.1.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
@@ -49,7 +49,7 @@ namespace Company.Function
 
             // Returns an HTTP 202 response with an instance management payload.
             // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
-            return client.CreateCheckStatusResponse(req, instanceId);
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
         }
     }
 }


### PR DESCRIPTION
We've received recent reports that the DF templates for .NET isolated have stopped working out of the box. This PR makes 3 fixes to address the feedback:

1. Updates the DF isolated extension to version 1.1.1 (can I use a `*` pattern to have it always download the latest?)

2. Updates the Http extension to version 3.1.0 (was getting the following warning otherwise)

"""
Warning As Error: Detected package downgrade: Microsoft.Azure.Functions.Worker.Extensions.Http from 3.1.0 to 3.0.13. Reference the package directly from the project to select a different version.

 FunctionApp2 -> Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 1.2.0 -> Microsoft.Azure.Functions.Worker.Extensions.Http (>= 3.1.0)

 FunctionApp2 -> Microsoft.Azure.Functions.Worker.Extensions.Http (>= 3.0.13)

"""

3. changes the use of `CreateCheckStatusResponse` to `CreateCheckStatusResponseAsync` which should address a runtime failure reading:

"""
Exception: System.InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
"""