### PR TITLE
Skipping oneLoc build for PRs from forks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ steps:
     packageSourceAuth: 'patAuth'
     patVariable: '$(ONELOCBUILD)'
     continueOnError: true
+    condition: and(succeeded(), eq($(System.PullRequest.IsFork), false))
 
 - task: CopyFiles@2
   enabled: true


### PR DESCRIPTION
Skipping One loc build step for PRs sent from forks