### PR TITLE
updating in-process proj template to support net8

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/.template.config/template.json
@@ -16,6 +16,23 @@
     },
     "sourceName": "Company.FunctionApp",
     "symbols": {
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "defaultValue": "net6.0",
+            "replaces": "TargetFrameworkValue",
+            "choices": [
+                {
+                "choice": "net6.0",
+                "description": "Target .NET 6"
+                },
+                {
+                "choice": "net8.0",
+                "description": "Target .NET 8"
+                }
+            ]
+        },
         "StorageConnectionStringValue": {
             "description": "The connection string for your Azure WebJobs Storage.",
             "type": "parameter",
@@ -26,7 +43,24 @@
         "AzureFunctionsVersion": {
             "description": "The setting that determines the target release",
             "type": "parameter",
-            "defaultValue": "V4",
+            "defaultValue": "V4"
+        },
+        "AzureFunctionsVersionAdjusted": {
+            "description": "Adjusted value for .NET 8",
+            "type": "generated",
+            "generator": "switch",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                {
+                    "condition": "(Framework == 'net8.0')",
+                    "value": "V4"
+                },
+                {
+                    "value": "(AzureFunctionsVersion)"
+                }
+                ]
+            },
             "replaces": "AzureFunctionsVersionValue"
         },
         "FunctionsHttpPort": {

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>TargetFrameworkValue</TargetFramework>
     <AzureFunctionsVersion>AzureFunctionsVersionValue</AzureFunctionsVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/Company.FunctionApp.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>TargetFrameworkValue</TargetFramework>
-    <AzureFunctionsVersion>AzureFunctionsVersionValue</AzureFunctionsVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp/local.settings.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp/local.settings.json
@@ -2,6 +2,9 @@
     "IsEncrypted": false,
     "Values": {
         "AzureWebJobsStorage": "AzureWebJobsStorageConnectionStringValue",
+//#if (Framework == 'net8.0')
+        "FUNCTIONS_INPROC_NET8_ENABLED": "1",
+//#endif
         "FUNCTIONS_WORKER_RUNTIME": "dotnet"
     }
 }

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp/.template.config/template.json
@@ -16,13 +16,53 @@
     },
     "sourceName": "Company.FunctionApp",
     "symbols": {
-      "StorageConnectionStringValue": {
-        "description": "The connection string for your Azure WebJobs Storage.",
-        "type": "parameter",
-        "defaultValue": "UseDevelopmentStorage=true",
-        "replaces": "AzureWebJobsStorageConnectionStringValue",
-        "DataType": "string"
-      }
+        "Framework": {
+            "type": "parameter",
+            "description": "The target framework for the project.",
+            "datatype": "choice",
+            "defaultValue": "net6.0",
+            "replaces": "TargetFrameworkValue",
+            "choices": [
+                {
+                    "choice": "net6.0",
+                    "description": "Target .NET 6"
+                },
+                {
+                    "choice": "net8.0",
+                    "description": "Target .NET 8"
+                }
+            ]
+        },
+        "StorageConnectionStringValue": {
+            "description": "The connection string for your Azure WebJobs Storage.",
+            "type": "parameter",
+            "defaultValue": "UseDevelopmentStorage=true",
+            "replaces": "AzureWebJobsStorageConnectionStringValue",
+            "DataType": "string"
+        },
+        "AzureFunctionsVersion": {
+            "description": "The setting that determines the target release",
+            "type": "parameter",
+            "defaultValue": "V4"
+        },
+        "AzureFunctionsVersionAdjusted": {
+            "description": "Adjusted value for .NET 8",
+            "type": "generated",
+            "generator": "switch",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "(Framework == 'net8.0')",
+                        "value": "V4"
+                    },
+                    {
+                        "value": "(AzureFunctionsVersion)"
+                    }
+                ]
+            },
+            "replaces": "AzureFunctionsVersionValue"
+        }
     },
     "sources": [
         {

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp/Company.FunctionApp.fsproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <TargetFramework>TargetFrameworkValue</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.FunctionApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="host.json">


### PR DESCRIPTION
Adding flexibility to the in-process template to support other TFMs. Draft PR while we await an appropriate version of the build SDK (4.4.0 does not exist at the time of this PR being opened).