### PR TITLE
.NET 9 template change for HttpTrigger

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -28,7 +28,7 @@
         "NetCore": {
             "type": "computed",
             "datatype": "bool",
-            "value": "(Framework == \"net6.0\" || Framework == \"net7.0\" || Framework == \"net8.0\")"
+            "value": "(Framework == \"net6.0\" || Framework == \"net7.0\" || Framework == \"net8.0\" || Framework == \"net9.0\")"
         },
         "namespace": {
             "description": "namespace for the generated code",


### PR DESCRIPTION
This PR adds .NET 9 as a target framework when creating a new HttpTrigger via core tools

Resolves: https://github.com/Azure/azure-functions-dotnet-worker/issues/2560