### PR TITLE
Add serverless agents template manifest entry

### DIFF
--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,7 +1,7 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
-**Total templates:** 77  
-**Manifest version:** 1.6.0
+**Total templates:** 78
+**Manifest version:** 1.8.0
 
 ## Design principles
 
@@ -103,6 +103,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | | **🤖 AI** | | | | |
 | 60 | `ai-agent-csharp` | .NET | trigger | ✅ bicep | P0→60 |
 | 60 | `ai-agent-python` | Py | trigger | ✅ bicep | P0→60 |
+| 60 | `ai-serverless-agents-python` | Py | trigger | ✅ bicep | *new* |
 | 60 | `ai-agent-typescript` | TS | trigger | ✅ bicep | P0→60 |
 | 60 | `ai-agent-java` | Java | trigger | ✅ bicep | P0→60 |
 | 61 | `ai-chatgpt-python` | Py | trigger | ✅ bicep | P1→61 |
@@ -186,7 +187,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 
 | Category | Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|---|
-| AI | Agent | P60 | ✅ | ✅ | ✅ | — | ✅ | — | JS, PS |
+| AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | JS, PS |
 |  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | .NET, TS, Java, PS |
 |  | Text Summarize | P62 | ✅ | ✅ | — | — | — | — | TS, JS, Java, PS |
 |  | LangChain | P63 | — | ✅ | — | — | — | — | .NET, TS, JS, Java, PS |
@@ -212,7 +213,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 50 | 🔌 MCP — Remote Server | 4 |
 | 51 | 🔌 MCP — SDK Hosting | 4 |
 | 55 | 🔌 MCP — APIM Gateway | 1 |
-| 60 | 🤖 AI — Agent | 4 |
+| 60 | 🤖 AI — Agent | 5 |
 | 61 | 🤖 AI — ChatGPT | 2 |
 | 62 | 🤖 AI — Text Summarize | 2 |
 | 63 | 🤖 AI — LangChain | 1 |
@@ -223,7 +224,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 72 | 🔄 Durable Advanced — PDF Summarizer | 2 |
 | 75 | 🤝 Agent Framework — Multi-Agent | 1 |
 | 90 | 🏗️ IaC — Flex Consumption (ARM / Bicep / TF) | 4 |
-| | **Total** | **77** |
+| | **Total** | **78** |
 
 ## Language sort order
 

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1797,18 +1797,14 @@
         "AI",
         "Agents",
         "Serverless",
-        "Markdown",
         "Microsoft Foundry",
-        "Dynamic Sessions",
         "MCP",
-        "Microsoft 365 Outlook",
-        "Preview",
         "AZD"
       ],
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-serverless-agents-azd",
       "folderPath": ".",
-      "gitRef": "refs/heads/main",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Chat agent defined in .agent.md with built-in debug chat UI and chat APIs",
         "Timer-triggered Microsoft blog summary agent",
@@ -1819,7 +1815,8 @@
         "Managed identity, storage, monitoring, and Flex Consumption hosting",
         "Bicep infrastructure files",
         "Azure Developer CLI (azd) configuration"
-      ]
+      ],
+      "isHighlighted": true
     },
     {
       "id": "ai-agent-typescript",

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-05-29T21:31:12Z",
+  "generatedAt": "2026-06-23T23:01:58Z",
   "version": "1.8.0",
-  "totalTemplates": 73,
+  "totalTemplates": 74,
   "runtimeVersions": {
     "Python": {
       "supported": [
@@ -1777,6 +1777,48 @@
         "Azure Developer CLI (azd) configuration",
         "Flex Consumption hosting",
         "Dev Container setup"
+      ]
+    },
+    {
+      "id": "ai-serverless-agents-python",
+      "displayName": "Serverless Agents (Python + AZD + Bicep)",
+      "shortDescription": "Markdown-first serverless agents with chat, timer trigger, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook MCP tools",
+      "longDescription": "Python Azure Functions app using the Azure Functions serverless agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 60,
+      "categories": [
+        "starters",
+        "gen-ai"
+      ],
+      "tags": [
+        "AI",
+        "Agents",
+        "Serverless",
+        "Markdown",
+        "Microsoft Foundry",
+        "Dynamic Sessions",
+        "MCP",
+        "Microsoft 365 Outlook",
+        "Preview",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-serverless-agents-azd",
+      "folderPath": ".",
+      "gitRef": "refs/heads/main",
+      "whatsIncluded": [
+        "Chat agent defined in .agent.md with built-in debug chat UI and chat APIs",
+        "Timer-triggered Microsoft blog summary agent",
+        "Azure Functions serverless agents runtime",
+        "Sandboxed Python code execution using Azure Container Apps dynamic sessions",
+        "Microsoft Foundry project and model deployment",
+        "Optional Connector Namespace and managed MCP server for Microsoft 365 Outlook",
+        "Managed identity, storage, monitoring, and Flex Consumption hosting",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add `ai-serverless-agents-python` to the template manifest
- Update manifest metadata and priority tier docs for the new AI serverless agents template
- Keep existing IaC Flex Consumption entries documented

## Validation
- Manifest schema validation
- Manifest `totalTemplates` count validation
- `git diff --check`