### PR TITLE
Default HTTP templates to function-level auth instead of anonymous

### DIFF
--- a/Functions.Templates/Documentation/mysqlIn.md
+++ b/Functions.Templates/Documentation/mysqlIn.md
@@ -17,7 +17,7 @@ This C# code example for getting data from Products table.
 ```csharp
 [FunctionName("GetProducts")]
   public static IActionResult Run(
-      [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
+      [HttpTrigger(AuthorizationLevel.Function, "get", Route = "getproducts/{cost}")]
       HttpRequest req,
       [MySql("select * from Products where Cost = @Cost",
           "MySqlConnectionString",

--- a/Functions.Templates/Documentation/mysqlOut.md
+++ b/Functions.Templates/Documentation/mysqlOut.md
@@ -14,7 +14,7 @@ This C# code example upserts Products to Products table.
 
 ```csharp
 public static IActionResult Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct")]
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "addproduct")]
         HttpRequest req, ILogger log,
         [MySql("Products", "MySqlConnectionString")]
         out Product[] output)

--- a/Functions.Templates/Documentation/signalRConnectionInfo.md
+++ b/Functions.Templates/Documentation/signalRConnectionInfo.md
@@ -20,7 +20,7 @@ This C# code example uses the binding to generate a valid connection info object
 ```csharp
 [FunctionName("negotiate")]
 public static SignalRConnectionInfo Negotiate(
-    [HttpTrigger(AuthorizationLevel.Anonymous)]HttpRequest req,
+    [HttpTrigger(AuthorizationLevel.Function)]HttpRequest req,
     [SignalRConnectionInfo(HubName = "chat")]SignalRConnectionInfo connectionInfo)
 {
     return connectionInfo;

--- a/Functions.Templates/Documentation/sqlIn.md
+++ b/Functions.Templates/Documentation/sqlIn.md
@@ -19,7 +19,7 @@ This C# code example for getting data from Products table. Please refer to our [
 ```csharp
 [FunctionName("GetProducts")]
   public static IActionResult Run(
-      [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
+      [HttpTrigger(AuthorizationLevel.Function, "get", Route = "getproducts/{cost}")]
       HttpRequest req,
       [Sql("select * from Products where Cost = @Cost",
           "SqlConnectionString",

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -16,7 +16,7 @@ This C# code example upserts employees to Employees table. Please refer to our [
 
 ```csharp
 public static IActionResult Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees")]
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "addemployees")]
         HttpRequest req, ILogger log,
         [Sql("dbo.Employees", "SqlConnectionString")]
         out Employee[] output)

--- a/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/dapr-publish-output_binding_template.md
+++ b/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/dapr-publish-output_binding_template.md
@@ -14,7 +14,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.function_name(name="DaprPublishOutputBindingPython")
 @app.timer_trigger(schedule="*/10 * * * * *", arg_name="myTimer", run_on_startup=False)

--- a/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/function_app.py
@@ -3,7 +3,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.timer_trigger(schedule="*/10 * * * * *", arg_name="myTimer", run_on_startup=False)
 @app.dapr_publish_output(arg_name="pubEvent", pub_sub_name="pubsub", topic="A")

--- a/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/dapr_service_invocation_trigger_template.md
+++ b/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/dapr_service_invocation_trigger_template.md
@@ -13,7 +13,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.function_name(name="DaprServiceInvocationTriggerPython")
 @app.dapr_service_invocation_trigger(arg_name="payload", method_name="DaprServiceInvocationTriggerPython")

--- a/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/function_app.py
@@ -2,7 +2,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.dapr_service_invocation_trigger(arg_name="payload", method_name="$(FUNCTION_NAME_INPUT)")
 def $(FUNCTION_NAME_INPUT)(payload: str) :

--- a/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/dapr-topic_trigger_template.md
+++ b/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/dapr-topic_trigger_template.md
@@ -13,7 +13,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.function_name(name="DaprTopicTriggerPython")
 @app.dapr_topic_trigger(arg_name="subEvent", pub_sub_name="pubsub", topic="A")

--- a/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/function_app.py
@@ -2,7 +2,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.dapr_topic_trigger(arg_name="subEvent", pub_sub_name="pubsub", topic="A")
 @app.dapr_state_output(arg_name="state", state_store="statestore", key="order")

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/function_app.py
@@ -4,7 +4,7 @@ import json
 import azure.functions as func
 import azure.durable_functions as df
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 #Entity Function
 @app.entity_trigger(context_name="context")

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/durable-orchestration_template.md
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/durable-orchestration_template.md
@@ -14,7 +14,7 @@ import logging
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.route(route="startOrchestrator")
 @app.durable_client_input(client_name="client")

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/function_app.py
@@ -2,7 +2,7 @@ import json
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # An HTTP-Triggered Function with a Durable Functions Client binding

--- a/Functions.Templates/Templates-v2/MCPResourceTrigger-Python/mcp_resource_trigger_template.md
+++ b/Functions.Templates/Templates-v2/MCPResourceTrigger-Python/mcp_resource_trigger_template.md
@@ -22,7 +22,7 @@ Following are example code snippets for MCP Resource Trigger using the [Python p
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 RESOURCE_METADATA = """
         {

--- a/Functions.Templates/Templates-v2/MCPToolTrigger-Python/mcp_tool_trigger_template.md
+++ b/Functions.Templates/Templates-v2/MCPToolTrigger-Python/mcp_tool_trigger_template.md
@@ -19,7 +19,7 @@ Following are example code snippets for MCP Tool using the [Python programming m
 ```python
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.mcp_tool()
 def my_mcp_tool(context: func.MCPToolContext) -> None:

--- a/Functions.Templates/Templates-v2/McpPromptTrigger-Python/mcp_prompt_trigger_template.md
+++ b/Functions.Templates/Templates-v2/McpPromptTrigger-Python/mcp_prompt_trigger_template.md
@@ -22,7 +22,7 @@ Following are example code snippets for MCP Prompt Trigger using the [Python pro
 import azure.functions as func
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 @app.mcp_prompt_trigger(
     arg_name="context",

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/.template.config/template.json
@@ -19,6 +19,27 @@
       "description": "namespace for the generated code",
       "replaces": "Company.Function",
       "type": "parameter"
+    },
+    "AccessRights": {
+      "type": "parameter",
+      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "Function",
+          "description": "Function"
+        },
+        {
+          "choice": "Anonymous",
+          "description": "Anonymous"
+        },
+        {
+          "choice": "Admin",
+          "description": "Admin"
+        }
+      ],
+      "replaces": "AuthLevelValue",
+      "defaultValue": "Function"
     }
   },
   "primaryOutputs": [

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/DaprServiceInvocationTriggerCSharp.cs
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/DaprServiceInvocationTriggerCSharp.cs
@@ -49,7 +49,7 @@ namespace Company.Function
         [Function("InvokeOutputBinding")]
         [DaprInvokeOutput(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")]
         public static async Task<InvokeMethodParameters> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequestData req, FunctionContext functionContext)
+            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequestData req, FunctionContext functionContext)
         {
             var log = functionContext.GetLogger("InvokeOutputBinding");
             log.LogInformation("C# HTTP trigger function processed a request.");

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/.template.config/template.json
@@ -19,6 +19,27 @@
       "description": "namespace for the generated code",
       "replaces": "Company.Function",
       "type": "parameter"
+    },
+    "AccessRights": {
+      "type": "parameter",
+      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "Function",
+          "description": "Function"
+        },
+        {
+          "choice": "Anonymous",
+          "description": "Anonymous"
+        },
+        {
+          "choice": "Admin",
+          "description": "Admin"
+        }
+      ],
+      "replaces": "AuthLevelValue",
+      "defaultValue": "Function"
     }
   },
   "primaryOutputs": [

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/DaprServiceInvocationTriggerCSharp.cs
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/DaprServiceInvocationTriggerCSharp.cs
@@ -49,7 +49,7 @@ namespace Company.Function
         /// </summary>
         [FunctionName("InvokeOutputBinding")]
         public static async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequest req,
             [DaprInvoke(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")] IAsyncCollector<InvokeMethodParameters> output,
             ILogger log)
         {

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/.template.config/template.json
@@ -19,6 +19,27 @@
       "replaces": "Company.Function",
       "type": "parameter"
     },
+    "AccessRights": {
+      "type": "parameter",
+      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "Function",
+          "description": "Function"
+        },
+        {
+          "choice": "Anonymous",
+          "description": "Anonymous"
+        },
+        {
+          "choice": "Admin",
+          "description": "Admin"
+        }
+      ],
+      "replaces": "AuthLevelValue",
+      "defaultValue": "Function"
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-1.x/DurableFunctionsOrchestrationCSharp.cs
@@ -34,7 +34,7 @@ namespace Company.Function
 
         [FunctionName("DurableFunctionsOrchestrationCSharp_HttpStart")]
         public static async Task<HttpResponseMessage> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]HttpRequestMessage req,
+            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")]HttpRequestMessage req,
             [OrchestrationClient]DurableOrchestrationClient starter,
             ILogger log)
         {

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
@@ -19,6 +19,27 @@
       "replaces": "Company.Function",
       "type": "parameter"
     },
+    "AccessRights": {
+      "type": "parameter",
+      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "Function",
+          "description": "Function"
+        },
+        {
+          "choice": "Anonymous",
+          "description": "Anonymous"
+        },
+        {
+          "choice": "Admin",
+          "description": "Admin"
+        }
+      ],
+      "replaces": "AuthLevelValue",
+      "defaultValue": "Function"
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/DurableFunctionsOrchestrationCSharp.cs
@@ -35,7 +35,7 @@ namespace Company.Function
 
         [FunctionName("DurableFunctionsOrchestrationCSharp_HttpStart")]
         public static async Task<HttpResponseMessage> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestMessage req,
+            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestMessage req,
             [DurableClient] IDurableOrchestrationClient starter,
             ILogger log)
         {

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
@@ -19,6 +19,27 @@
       "replaces": "Company.Function",
       "type": "parameter"
     },
+    "AccessRights": {
+      "type": "parameter",
+      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "Function",
+          "description": "Function"
+        },
+        {
+          "choice": "Anonymous",
+          "description": "Anonymous"
+        },
+        {
+          "choice": "Admin",
+          "description": "Admin"
+        }
+      ],
+      "replaces": "AuthLevelValue",
+      "defaultValue": "Function"
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
@@ -35,7 +35,7 @@ public static class DurableFunctionsOrchestrationCSharp
 
     [Function("DurableFunctionsOrchestrationCSharp_HttpStart")]
     public static async Task<HttpResponseData> HttpStart(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestData req,
         [DurableClient] DurableTaskClient client,
         FunctionContext executionContext)
     {

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/.template.config/template.json
@@ -20,6 +20,27 @@
             "replaces": "Company.Function",
             "type": "parameter"
         },
+        "AccessRights": {
+            "type": "parameter",
+            "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
+            "datatype": "choice",
+            "choices": [
+                {
+                    "choice": "Function",
+                    "description": "Function"
+                },
+                {
+                    "choice": "Anonymous",
+                    "description": "Anonymous"
+                },
+                {
+                    "choice": "Admin",
+                    "description": "Admin"
+                }
+            ],
+            "replaces": "AuthLevelValue",
+            "defaultValue": "Function"
+        },
         "BrokerList": {
             "description": "List of the brokers",
             "type": "parameter",

--- a/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
+++ b/Functions.Templates/Templates/KafkaOutput-CSharp/KafkaOutputCSharp.cs
@@ -14,7 +14,7 @@ namespace Company.Function
         // Call this function then the KafkaTrigger will be trigged.
         [FunctionName("KafkaOutputCSharp")]
         public IActionResult Output(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", Route = null)] HttpRequest req,
             [Kafka("BrokerList",
                    "topic",
                    Username = "$ConnectionString",


### PR DESCRIPTION
## Description

Stop HTTP-triggered templates from defaulting to anonymous authorization.

**C# templates** (Dapr ServiceInvocation x2, Durable Orchestration 1.x/2.x/Isolated, Kafka Output): replaced the hard-coded `AuthorizationLevel.Anonymous` with the `AuthLevelValue` token and added an `AccessRights` choice parameter (`Function`/`Anonymous`/`Admin`, default `Function`), matching the existing `HttpTrigger-CSharp` convention.

**C# documentation snippets** (mysqlIn/Out, sqlIn/Out, signalRConnectionInfo): set to `AuthorizationLevel.Function`.

**Python v2 templates** (Dapr, Durable, MCP, Entity): removed `http_auth_level=func.AuthLevel.ANONYMOUS`

## Related issues

- https://github.com/Azure/azure-functions-bucees-planning/issues/1101
- https://github.com/Azure/azure-functions-bucees-planning/issues/1103

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [x] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [ ] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
