### PR TITLE
manifest: Add connector + JS MCP samples, update runtime versions, add manifest skill

### DIFF
--- a/.github/skills/add-manifest-sample/SKILL.md
+++ b/.github/skills/add-manifest-sample/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: add-manifest-sample
+description: >-
+  Add a new Azure Functions sample/quickstart to the Template Manifest. Use when
+  asked to "add a sample", "add a template", "register a quickstart", or
+  "add a connector/MCP/trigger sample" to
+  Functions.Templates/Template-Manifest/manifest.json. Covers required fields,
+  the short/long description pattern, category rules, priority assignment,
+  metadata bumps (count/version/generatedAt), and keeping docs/priority-tiers.md
+  in sync.
+---
+
+# Add a new sample to the Template Manifest
+
+This skill explains how to register a new template in the Azure Functions
+Template Manifest so it appears in the VS Code Azure Functions extension and
+other consumers.
+
+## Who consumes the manifest
+
+Changes to `manifest.json` are surfaced by multiple downstream consumers, so keep
+entries accurate and validated:
+
+- **Azure Functions VS Code Extension** — shows templates (and their
+  `categories`) in the create-project / create-sample experience.
+- **Azure Functions CLI (Core Tools) v5** — quickstart command uses the manifest to list and
+  scaffold samples.
+- **Azure MCP tool** — exposes the manifest's templates to MCP clients/agents in Azure Functions Tools.
+- **Azure skills** — Copilot/agent skills that read the manifest to recommend or
+  generate Functions samples (entry point Azure MCP Tool)
+
+## Files you will touch
+
+| File | Purpose |
+|---|---|
+| `Functions.Templates/Template-Manifest/manifest.json` | Source of truth. Add the template object + bump metadata. |
+| `Functions.Templates/Template-Manifest/schemas/manifest.schema.json` | JSON Schema. Only edit to add a **new enum value** (e.g. a new `resource`). Note: `categories` are **not** a schema enum — they are free-form kebab-case (pattern-validated), so adding a category needs **no** schema change. |
+| `Functions.Templates/Template-Manifest/docs/priority-tiers.md` | Human-readable priority/coverage doc. Keep in sync with the manifest. |
+
+The manifest file is written as canonical `json.dumps(indent=2, ensure_ascii=False)`
+output with a trailing newline. Preserve that formatting (2-space indent, no
+trailing whitespace).
+
+## Step 1 — Inspect the source repository first
+
+Never guess what a sample does. Inspect the actual repo at the exact tag you will
+pin (`gitRef`) and confirm:
+
+- The folder (`folderPath`) and tag (`gitRef`) exist.
+- The real trigger/function names.
+- Whether it actually uses a binding you plan to mention. For example, only claim
+  "Blob output" if the code really has a Blob output binding — sibling samples in
+  different languages often differ (e.g. C# may use `BlobOutput` while the
+  TypeScript/Python ports only log the payload).
+
+```powershell
+gh api "repos/<owner>/<repo>/contents/<folderPath>?ref=refs/tags/<tag>" --jq '.[] | "\(.type)\t\(.name)"'
+```
+
+## Step 2 — Add the template object
+
+Insert the template object adjacent to its peer entries (same `resource` value)
+in the `templates` array, maintaining priority order within that group. If no
+peers exist, append to the end of the array. Mirror the existing entry for the
+same family/resource so the new one is consistent.
+
+### Mandatory fields for a new sample
+
+A new template **must** include **all** of the following.
+
+**Enforced by the schema:**
+`id`, `displayName`, `shortDescription`, `longDescription`, `language`, `bindingType`, `resource`,
+`iac`, `priority`, `categories`, `repositoryUrl`, `folderPath`, `gitRef`.
+
+Other fields (`whatsIncluded`, `author`, `isHighlighted`) are
+optional but recommended where applicable. **`tags` is deprecated — do not add it.**
+
+### Field rules
+
+- **`id`** — kebab-case, unique (matches the schema `id` pattern). Convention:
+  `<resource-or-feature>-<binding>-<language>` (e.g. `office365-connector-trigger-python`).
+  Before adding the entry, search `templates` for a matching `id`. If a collision
+  is found, inform the user and suggest an alternative `id` (for example, append
+  a version suffix or disambiguating term). Never silently overwrite or duplicate
+  an `id`.
+- **`displayName`** — `"<Friendly Name> (<Lang> + AZD + Bicep)"`.
+- **`language`** — must be one of the schema `language` enum values.
+- **`bindingType`** — must be one of the schema `bindingType` enum values.
+- **`resource`** — must be one of the schema `resource` enum values. Add a new
+  enum value to `manifest.schema.json` **only** if none fits, and reuse it
+  consistently.
+- **`iac`** — must be one of the schema `iac` enum values.
+- The same enum-extension rule applies to `language`, `bindingType`, and `iac`:
+  add a new enum value in `manifest.schema.json` only when no existing value fits,
+  then reuse it consistently across related samples. When any enum is extended,
+  bump manifest `version` with a minor increment.
+- **`repositoryUrl`** — must satisfy the schema pattern (GitHub HTTPS URL).
+- **`folderPath`** — path within the repo (`.` for root).
+- **`gitRef`** — **mandatory for new samples.** Always pin a signed release tag,
+  e.g. `refs/tags/v1.0.0`. Never leave it unset and never point a new sample at a
+  moving branch (`refs/heads/main`) — that makes the template non-reproducible.
+  Verify the tag exists before committing. **Whenever the sample repo ships a new
+  release, ask the user to update `gitRef` to the new tag** (and re-verify the
+  pinned `folderPath`/contents still match) so the manifest tracks the intended
+  release.
+  If the `gitRef` tag does not exist in the target repository, do not proceed
+  with adding the template. Inform the user that the tag was not found, provide
+  the exact `gh api` command used to verify, and ask them to confirm the tag name
+  or create the release first.
+
+The allowed values, patterns, and limits for every field are defined in
+`schemas/manifest.schema.json` — read them there rather than relying on a copy.
+A quick way to print the enums:
+
+```powershell
+cd Functions.Templates\Template-Manifest
+@'
+import json
+p = json.load(open(r"schemas\manifest.schema.json", encoding="utf-8"))["$defs"]["template"]["properties"]
+for f in ("language", "bindingType", "resource", "iac"):
+    print(f, "->", p[f]["enum"])
+'@ | python -
+```
+
+### Categories (match existing — shown in VS Code)
+
+`categories` are displayed/filtered in the VS Code extension, so **only use
+categories that already exist in the manifest** unless you have a deliberate reason
+to introduce a new one. Derive the current set from the manifest instead of
+hardcoding it:
+
+```powershell
+cd Functions.Templates\Template-Manifest
+@'
+import json
+d = json.load(open("manifest.json", encoding="utf-8"))
+print(sorted({c for t in d["templates"] for c in t["categories"]}))
+'@ | python -
+```
+
+Most starter samples include `starters` plus a domain category
+(e.g. `["starters", "connectors", "event-processing"]`). Values are kebab-case.
+
+### `tags` are deprecated
+
+**Do not add a `tags` array to new entries.** It is deprecated and not used by
+consumers. (Older entries may still contain it; leave those as-is unless asked.)
+
+### Description pattern
+
+Match the established pattern used across the manifest:
+
+- **`shortDescription`** (respect the schema's `maxLength`): a concise capability
+  summary that ends with **`deployed via azd`** for azd-based templates.
+  Pattern: `"<Service> <scope> <mechanism>, deployed via azd"`.
+  Example: `"Office 365 Outlook email and calendar connector triggers with Blob output, deployed via azd"`.
+  If the sample is not azd-based (for example, `iac` is `none` or deployment is
+  manual), omit the `deployed via azd` suffix. End with the real deployment
+  mechanism (for example, `deployed via ARM template`) or with the capability
+  summary when no deployment mechanism is represented.
+
+- **`longDescription`**: start with the imperative
+  **`Build and deploy …`**, then **explicitly name the trigger(s) and binding(s)
+  the sample demonstrates** — e.g. the specific trigger type(s)
+  (`ConnectorTrigger`, `McpToolTrigger`, `CosmosDBTrigger`, …) and any input/output
+  bindings (`BlobInput`/`BlobOutput`, etc.). Enumerate `(1) … (2) …` when there are
+  multiple functions/tools, naming each one. Only list a binding if the sample's
+  code actually uses it (verify per language — siblings often differ). Then name
+  the SDK/extension, give the hosting/auth summary, and **end with
+  `Deployed with azd.`**
+  For non-azd samples, omit the `Deployed with azd.` closing and end with the
+  deployment approach actually used or a neutral capability summary.
+
+- **`whatsIncluded`**: a short list of concrete artifacts (functions, bindings,
+  infra, azd config). Keep claims accurate to the real sample.
+
+### Example object
+
+```json
+{
+  "id": "office365-connector-trigger-python",
+  "displayName": "Office 365 Outlook Connector Triggers (Python + AZD + Bicep)",
+  "shortDescription": "Office 365 Outlook email and calendar connector triggers, deployed via azd",
+  "longDescription": "Build and deploy an Office 365 Outlook connector app on Azure Functions in Python. This app provides five connector trigger functions ... Deployed with azd.",
+  "language": "Python",
+  "bindingType": "trigger",
+  "resource": "connector",
+  "iac": "bicep",
+  "priority": 80,
+  "categories": ["starters", "connectors", "event-processing"],
+  "author": "Azure Functions Team",
+  "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-python",
+  "folderPath": "office365App",
+  "gitRef": "refs/tags/v1.0.0",
+  "whatsIncluded": ["..."]
+}
+```
+
+`isHighlighted: true` is optional and only for samples that should be
+featured/highlighted in the consuming UI (e.g. VS Code).
+
+## Step 3 — Choose a priority
+
+`priority` is the primary sort key (lower = shown first), an integer within the
+range defined by the schema's `priority` bounds. It is organized in blocks (see
+`docs/priority-tiers.md`):
+
+- 5-slot blocks per Azure resource: `+0` trigger, `+1` input, `+2` output,
+  `+3` variant, `+4` stub.
+- 10-slot block for MCP (P50–59).
+- Language samples that share a sub-type share the same priority and are sorted by
+  language order: **.NET → Python → TypeScript → JavaScript → Java → PowerShell**.
+
+Use this lookup style to avoid inferring block math from memory. Build/update this
+table from `docs/priority-tiers.md` before assigning a new value:
+
+| Resource | Block Start | trigger | input | output | variant |
+|---|---:|---:|---:|---:|---:|
+| mcp | 50 | 50 | 51 | 52 | 53 |
+| connector | 80 | 80 | 81 | 82 | 83 |
+
+If the target resource/block is unclear or overlaps with existing assignments,
+stop and confirm the intended block with the user before setting `priority`.
+
+Reuse the priority of the matching peer template (e.g. all Office 365 connector
+samples = P80, all SharePoint = P81). Use the next free slot/block for a brand-new
+category.
+
+## Step 4 — Bump manifest metadata
+
+In `manifest.json`, update the top-level fields:
+
+- **`totalTemplates`** — must equal the number of objects in `templates`.
+- **`version`** — bump semver (minor bump for new templates / a new `resource`
+  enum value; patch for description-only fixes).
+  Use these exact rules: bump the **minor** version (for example, `1.2.0` →
+  `1.3.0`) if the PR adds one or more new templates or introduces a new enum
+  value (`resource`, `language`, `bindingType`, or `iac`). Bump the **patch**
+  version (for example, `1.2.0` → `1.2.1`) if the PR only fixes descriptions or
+  metadata without adding/removing templates or extending enums. If both occur in
+  one PR, use the higher bump (minor).
+- **`generatedAt`** — current UTC time in `YYYY-MM-DDTHH:MM:SSZ`.
+
+## Step 5 — Update `docs/priority-tiers.md`
+
+Keep the doc in sync with the manifest:
+
+- Update the header **Total templates** and **Manifest version**.
+- Add the new row(s) to the **Full template listing** (use `*new*` in the *Was*
+  column), in priority → language order.
+- Update the **Priority block map** and **Coverage matrix** if you added a
+  sub-type/category, and the **Summary** counts and **Total** (must match
+  `totalTemplates`).
+- If samples are removed (e.g. archived repos), delete their rows and note the
+  removal in the block map / coverage matrix (e.g. `*(removed — repos archived)*`).
+
+## Step 6 — Validate
+
+Always validate JSON parses and conforms to the schema, and that the counts match
+(install the validator first if needed: `pip install jsonschema`):
+
+```powershell
+cd Functions.Templates\Template-Manifest
+@'
+import json, jsonschema
+d = json.load(open("manifest.json", encoding="utf-8"))
+s = json.load(open(r"schemas\manifest.schema.json", encoding="utf-8"))
+jsonschema.validate(d, s)
+assert d["totalTemplates"] == len(d["templates"]), "totalTemplates mismatch"
+print("OK:", len(d["templates"]), "templates, version", d["version"])
+'@ | python -
+```
+
+Also confirm a full-file round-trip produces no unintended formatting drift before
+and after large edits:
+
+```python
+orig = open("manifest.json", encoding="utf-8").read()
+import json
+assert orig == json.dumps(json.loads(orig), indent=2, ensure_ascii=False) + "\n"
+```
+
+### Validate template references on GitHub
+
+Run the repo's reference validator, which checks that every template's
+`repositoryUrl`, `gitRef`, and `folderPath` actually resolve on GitHub (and warns
+when a `gitRef` is a branch instead of a signed tag). Requires an authenticated
+`gh` CLI:
+
+```powershell
+pwsh -NoProfile -File eng\scripts\validate-manifest-refs.ps1
+```
+
+The script validates the whole manifest, so pre-existing `refs/heads/*` branch
+entries may already emit warnings. **For the sample(s) you added or changed, the
+output must show `OK` with no `WARN`/`ERROR` lines** — i.e. the repo, tag, and
+folder resolve and `gitRef` is a signed tag (`refs/tags/*`). Fix any error and
+re-run until your entries are clean before committing.
+
+## Checklist
+
+- [ ] Verified repo, `folderPath`, and `gitRef` (tag) exist; claims match real code.
+- [ ] `gitRef` set to a pinned release tag (mandatory; not a moving branch).
+- [ ] Template object added with all mandatory fields (incl. `gitRef`); `id` unique.
+- [ ] `displayName` follows `"<Friendly Name> (<Lang> + AZD + Bicep)"`.
+- [ ] `categories` use only existing values; **no `tags`** on new entries.
+- [ ] `shortDescription` follows deployment mode rules: for azd templates it ends with
+  `deployed via azd`; for non-azd templates it omits that suffix and uses the
+  actual deployment mechanism (or a capability-only ending).
+- [ ] `longDescription` starts with `Build and deploy …`, **explicitly names the
+  trigger(s)/binding(s) demonstrated**; for azd templates it ends with
+  `Deployed with azd.`, and for non-azd templates it omits that closing and
+  uses the actual deployment approach (or a neutral capability summary).
+- [ ] `priority` matches peers / correct block.
+- [ ] `totalTemplates`, `version`, `generatedAt` updated.
+- [ ] `docs/priority-tiers.md` listing, block map, coverage matrix, and totals updated.
+- [ ] JSON parses, schema validates, counts match; no formatting drift (round-trip).
+- [ ] `eng\scripts\validate-manifest-refs.ps1` shows `OK` (no `WARN`/`ERROR`) for
+      the sample(s) you touched.

--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,6 +1,6 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
-**Total templates:** 77
+**Total templates:** 75
 **Manifest version:** 1.9.0
 
 ## Design principles
@@ -29,7 +29,7 @@
 | P40–44 | 🗄️ SQL | Trigger · Input · Output | `P40` Trigger<br>`P41` Input *(future)*<br>`P42` Output *(future)* |
 | P45–49 | 🔴 Redis *(reserved)* | Trigger · Input · Output | `P45` Trigger<br>`P46` Input<br>`P47` Output |
 | P50–59 | 🔌 MCP *(10-slot block)* | Trigger (Tool / Resource / Prompt) | `P50` Remote Server<br>`P51` SDK Hosting *(removed — repos archived)*<br>`P52` Tool<br>`P53` Resource<br>`P54` Prompt<br>`P55` APIM Gateway<br>`P56` *(reserved)*<br>`P57` *(reserved)*<br>`P58` *(reserved)*<br>`P59` *(reserved)* |
-| P60–64 | 🤖 AI | — | `P60` Agent<br>`P61` ChatGPT<br>`P62` Text Summarize<br>`P63` LangChain |
+| P60–64 | 🤖 AI | — | `P60` Agent<br>`P61` ChatGPT<br>`P62` Text Summarize *(removed — repos archived)*<br>`P63` LangChain |
 | P65–69 | 🔄 Durable Standard | Orchestration | `P65` Orchestration<br>`P66` Order Processor |
 | P70–74 | 🔄 Durable Advanced | Orchestration | `P70` Patterns (saga / tracing / payload)<br>`P71` Scenarios (travel / aspire)<br>`P72` PDF Summarizer |
 | P75–79 | 🤝 Agent Framework | Orchestration | `P75` Multi-Agent |
@@ -105,8 +105,6 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 60 | `ai-agent-java` | Java | trigger | ✅ bicep | P0→60 |
 | 61 | `ai-chatgpt-python` | Py | trigger | ✅ bicep | P1→61 |
 | 61 | `ai-chatgpt-javascript` | JS | trigger | ✅ bicep | P1→61 |
-| 62 | `ai-textsummarize-csharp` | .NET | trigger | ✅ bicep | P2→62 |
-| 62 | `ai-textsummarize-python` | Py | trigger | ✅ bicep | P2→62 |
 | 63 | `ai-langchain-python` | Py | trigger | ✅ bicep | P2→63 |
 | | **🔄 Durable Standard** | | | | |
 | 65 | `durable-orchestrator-csharp-azd` | .NET | orchestration | ✅ bicep | *new* |
@@ -133,6 +131,16 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 81 | `sharepoint-connector-trigger-csharp` | .NET | trigger | ✅ bicep | *new* |
 | 81 | `sharepoint-connector-trigger-python` | Py | trigger | ✅ bicep | *new* |
 | 81 | `sharepoint-connector-trigger-typescript` | TS | trigger | ✅ bicep | *new* |
+
+### Removed (archived repos)
+
+These templates were removed because their source repositories were **archived**:
+
+| Removed template(s) | P | Archived repo(s) |
+|---|--:|---|
+| `mcp-sdk-hosting-csharp` / `-python` / `-typescript` / `-java` | P51 | `Azure-Samples/mcp-sdk-functions-hosting-{dotnet,python,node,java}` |
+| `ai-textsummarize-csharp` | P62 | `Azure-Samples/function-csharp-ai-textsummarize` |
+| `ai-textsummarize-python` | P62 | `Azure-Samples/function-python-ai-textsummarize` |
 
 ## Coverage matrix
 
@@ -186,7 +194,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 |---|---|---|---|---|---|---|---|---|---|
 | AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | JS, PS |
 |  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | .NET, TS, Java, PS |
-|  | Text Summarize | P62 | ✅ | ✅ | — | — | — | — | TS, JS, Java, PS |
+|  | Text Summarize | P62 | — | — | — | — | — | — | *removed (repos archived)* |
 |  | LangChain | P63 | — | ✅ | — | — | — | — | .NET, TS, JS, Java, PS |
 | Durable | Orchestration | P65 | ✅ | ✅ | ✅ | 🚧 | — | — | Java, PS |
 |  | Order Processor | P66 | ✅ | ✅ | — | — | — | — | TS, JS, Java, PS |
@@ -218,7 +226,6 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 55 | 🔌 MCP — APIM Gateway | 1 |
 | 60 | 🤖 AI — Agent | 5 |
 | 61 | 🤖 AI — ChatGPT | 2 |
-| 62 | 🤖 AI — Text Summarize | 2 |
 | 63 | 🤖 AI — LangChain | 1 |
 | 65 | 🔄 Durable Standard — Orchestration | 4 |
 | 66 | 🔄 Durable Standard — Order Processor | 2 |
@@ -228,7 +235,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 75 | 🤝 Agent Framework — Multi-Agent | 1 |
 | 80 | 🔌 Connectors — Office 365 Outlook | 3 |
 | 81 | 🔌 Connectors — SharePoint Online | 3 |
-| | **Total** | **77** |
+| | **Total** | **75** |
 
 ## Language sort order
 

--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,7 +1,7 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
-**Total templates:** 78
-**Manifest version:** 1.8.0
+**Total templates:** 77
+**Manifest version:** 1.9.0
 
 ## Design principles
 
@@ -28,12 +28,12 @@
 | P35–39 | 🌐 Cosmos DB | Trigger · Input · Output | `P35` Trigger<br>`P36` Input *(future)*<br>`P37` Output *(future)* |
 | P40–44 | 🗄️ SQL | Trigger · Input · Output | `P40` Trigger<br>`P41` Input *(future)*<br>`P42` Output *(future)* |
 | P45–49 | 🔴 Redis *(reserved)* | Trigger · Input · Output | `P45` Trigger<br>`P46` Input<br>`P47` Output |
-| P50–59 | 🔌 MCP *(10-slot block)* | Trigger (Tool / Resource / Prompt) | `P50` Remote Server<br>`P51` SDK Hosting<br>`P52` Tool<br>`P53` Resource<br>`P54` Prompt<br>`P55` APIM Gateway<br>`P56` *(reserved)*<br>`P57` *(reserved)*<br>`P58` *(reserved)*<br>`P59` *(reserved)* |
+| P50–59 | 🔌 MCP *(10-slot block)* | Trigger (Tool / Resource / Prompt) | `P50` Remote Server<br>`P51` SDK Hosting *(removed — repos archived)*<br>`P52` Tool<br>`P53` Resource<br>`P54` Prompt<br>`P55` APIM Gateway<br>`P56` *(reserved)*<br>`P57` *(reserved)*<br>`P58` *(reserved)*<br>`P59` *(reserved)* |
 | P60–64 | 🤖 AI | — | `P60` Agent<br>`P61` ChatGPT<br>`P62` Text Summarize<br>`P63` LangChain |
 | P65–69 | 🔄 Durable Standard | Orchestration | `P65` Orchestration<br>`P66` Order Processor |
 | P70–74 | 🔄 Durable Advanced | Orchestration | `P70` Patterns (saga / tracing / payload)<br>`P71` Scenarios (travel / aspire)<br>`P72` PDF Summarizer |
 | P75–79 | 🤝 Agent Framework | Orchestration | `P75` Multi-Agent |
-| P80–89 | — *(reserved for future categories)* | — | — |
+| P80–89 | 🔌 Connectors | Trigger | `P80` Office 365 Outlook<br>`P81` SharePoint Online |
 | P90–94 | 🏗️ IaC | — | `P90` Flex Consumption (ARM / Bicep / TF) |
 | P95–99 | ⚠️ Non-AZD Stubs | — | `P95` Gap-fillers (AZD upgrade planned) |
 
@@ -94,11 +94,8 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 50 | `mcp-server-remote-csharp` | .NET | trigger | ✅ bicep | P0→50 |
 | 50 | `mcp-server-remote-python` | Py | trigger | ✅ bicep | P0→50 |
 | 50 | `mcp-server-remote-typescript` | TS | trigger | ✅ bicep | P0→50 |
+| 50 | `mcp-server-remote-javascript` | JS | trigger | ✅ bicep | *new* |
 | 50 | `mcp-server-remote-java` | Java | trigger | ✅ bicep | P0→50 |
-| 51 | `mcp-sdk-hosting-csharp` | .NET | trigger | ✅ bicep | P1→51 |
-| 51 | `mcp-sdk-hosting-python` | Py | trigger | ✅ bicep | P1→51 |
-| 51 | `mcp-sdk-hosting-typescript` | TS | trigger | ✅ bicep | P1→51 |
-| 51 | `mcp-sdk-hosting-java` | Java | trigger | ✅ bicep | P1→51 |
 | 55 | `mcp-server-apim-python` | Py | trigger | ✅ bicep | P2→55 |
 | | **🤖 AI** | | | | |
 | 60 | `ai-agent-csharp` | .NET | trigger | ✅ bicep | P0→60 |
@@ -129,13 +126,13 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 72 | `durable-pdf-summarizer-python` | Py | orchestration | 🚧 none | P2→72 |
 | | **🤝 Agent Framework** | | | | |
 | 75 | `agentframework-durable-multi-agent-python` | Py | orchestration | 🚧 none | P1→75 |
-| | **🏗️ IaC** | | | | |
-| 90 | `iac-flex-consumption-arm` | ARM | none | 📦 arm | P2→90 |
-| 90 | `iac-flex-consumption-bicep` | Bicep | none | 📦 bicep | P2→90 |
-| 90 | `iac-flex-consumption-terraform-azapi` | TF | none | 📦 terraform | P2→90 |
-| 90 | `iac-flex-consumption-terraform-azurerm` | TF | none | 📦 terraform | P2→90 |
-| | **⚠️ Non-AZD Stubs** | | | | |
-| | *(none — all stubs replaced by AZD versions)* | | | | |
+| | **🔌 Connectors** | | | | |
+| 80 | `office365-connector-trigger-csharp` | .NET | trigger | ✅ bicep | *new* |
+| 80 | `office365-connector-trigger-python` | Py | trigger | ✅ bicep | *new* |
+| 80 | `office365-connector-trigger-typescript` | TS | trigger | ✅ bicep | *new* |
+| 81 | `sharepoint-connector-trigger-csharp` | .NET | trigger | ✅ bicep | *new* |
+| 81 | `sharepoint-connector-trigger-python` | Py | trigger | ✅ bicep | *new* |
+| 81 | `sharepoint-connector-trigger-typescript` | TS | trigger | ✅ bicep | *new* |
 
 ## Coverage matrix
 
@@ -176,8 +173,8 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 
 | Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|
-| Remote Server | P50 | ✅ | ✅ | ✅ | — | ✅ | — | JS, PS |
-| SDK Hosting | P51 | ✅ | ✅ | ✅ | — | ✅ | — | JS, PS |
+| Remote Server | P50 | ✅ | ✅ | ✅ | ✅ | ✅ | — | PS |
+| SDK Hosting | P51 | — | — | — | — | — | — | *removed (repos archived)* |
 | Tool | P52 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | *no dedicated templates yet* |
 | Resource | P53 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | *no dedicated templates yet* |
 | Prompt | P54 | 🔗 | — | — | — | — | — | *no dedicated templates yet* |
@@ -198,6 +195,13 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 |  | PDF Summarizer | P72 | 🚧 | 🚧 | — | — | — | — | TS, JS, Java, PS |
 | Agent Fw | Multi-Agent | P75 | — | 🚧 | — | — | — | — | .NET, TS, JS, Java, PS |
 
+### Connectors (P80–P89)
+
+| Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
+|---|---|---|---|---|---|---|---|---|
+| Office 365 Outlook | P80 | ✅ | ✅ | ✅ | — | — | — | JS, Java, PS |
+| SharePoint Online | P81 | ✅ | ✅ | ✅ | — | — | — | JS, Java, PS |
+
 ## Summary
 
 | P | Slot label | Templates |
@@ -210,8 +214,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 30 | 🚌 Service Bus — Trigger | 6 |
 | 35 | 🌐 Cosmos DB — Trigger | 6 |
 | 40 | 🗄️ SQL — Trigger | 3 |
-| 50 | 🔌 MCP — Remote Server | 4 |
-| 51 | 🔌 MCP — SDK Hosting | 4 |
+| 50 | 🔌 MCP — Remote Server | 5 |
 | 55 | 🔌 MCP — APIM Gateway | 1 |
 | 60 | 🤖 AI — Agent | 5 |
 | 61 | 🤖 AI — ChatGPT | 2 |
@@ -223,8 +226,9 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 71 | 🔄 Durable Advanced — Scenarios (travel / aspire) | 2 |
 | 72 | 🔄 Durable Advanced — PDF Summarizer | 2 |
 | 75 | 🤝 Agent Framework — Multi-Agent | 1 |
-| 90 | 🏗️ IaC — Flex Consumption (ARM / Bicep / TF) | 4 |
-| | **Total** | **78** |
+| 80 | 🔌 Connectors — Office 365 Outlook | 3 |
+| 81 | 🔌 Connectors — SharePoint Online | 3 |
+| | **Total** | **77** |
 
 ## Language sort order
 

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-06-23T23:01:58Z",
-  "version": "1.8.0",
-  "totalTemplates": 74,
+  "generatedAt": "2026-06-30T21:06:27Z",
+  "version": "1.9.0",
+  "totalTemplates": 77,
   "runtimeVersions": {
     "Python": {
       "supported": [
@@ -18,20 +18,14 @@
     },
     "JavaScript": {
       "supported": [
-        "20",
-        "22"
-      ],
-      "preview": [
+        "22",
         "24"
       ],
       "default": "22"
     },
     "TypeScript": {
       "supported": [
-        "20",
-        "22"
-      ],
-      "preview": [
+        "22",
         "24"
       ],
       "default": "22"
@@ -44,7 +38,7 @@
         "21",
         "25"
       ],
-      "default": "21"
+      "default": "17"
     },
     "CSharp": {
       "supported": [
@@ -65,6 +59,13 @@
       "preview": [
         "7.6"
       ]
+    },
+    "Go": {
+      "supported": [],
+      "preview": [
+        "1.24"
+      ],
+      "default": "1.24"
     }
   },
   "languages": [
@@ -1440,8 +1441,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support",
         "Dev Container setup"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-server-remote-python",
@@ -1477,8 +1477,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support",
         "Dev Container setup"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-server-remote-typescript",
@@ -1515,8 +1514,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support",
         "Dev Container setup"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-server-remote-java",
@@ -1552,127 +1550,36 @@
         "Maven build configuration",
         "VS Code mcp.json configuration",
         "MCP Inspector support"
-      ],
-      "isHighlighted": true
-    },
-    {
-      "id": "mcp-sdk-hosting-csharp",
-      "displayName": "Self-hosted MCP SDK Server (C# + AZD + Bicep)",
-      "shortDescription": "Hosts MCP tools via HTTP/SSE transport using ModelContextProtocol.AspNetCore SDK",
-      "longDescription": "C# ASP.NET Core application hosting MCP protocol tools (weather, user info) via HTTP/SSE transport using the ModelContextProtocol.AspNetCore SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
-      "language": "CSharp",
-      "bindingType": "trigger",
-      "resource": "MCP",
-      "iac": "bicep",
-      "priority": 51,
-      "categories": [
-        "gen-ai"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-dotnet",
-      "folderPath": ".",
-      "gitRef": "refs/heads/main",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
       ]
     },
     {
-      "id": "mcp-sdk-hosting-python",
-      "displayName": "Self-hosted MCP SDK Server (Python + AZD + Bicep)",
-      "shortDescription": "Hosts MCP tools via Starlette/ASGI transport using FastMCP SDK",
-      "longDescription": "Python application hosting MCP protocol tools (weather) using the FastMCP SDK (mcp.server.fastmcp) with Starlette/ASGI transport. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
-      "language": "Python",
+      "id": "mcp-server-remote-javascript",
+      "displayName": "Remote MCP Server (JavaScript + AZD + Bicep)",
+      "shortDescription": "Weather and code snippet tools with Blob storage, deployed via azd",
+      "longDescription": "Build and deploy a remote MCP server on Azure Functions in JavaScript. Includes two sample apps: (1) McpToolTrigger (mcpTool) for building custom tools, demonstrated with hello world and snippet save/retrieve using BlobInput/BlobOutput, and (2) McpWeatherApp combining mcpTool and mcpResource for exposing server-side data as resources, with an interactive Vite UI. Secured with Entra ID authentication. Deployed with azd.",
+      "language": "JavaScript",
       "bindingType": "trigger",
       "resource": "MCP",
       "iac": "bicep",
-      "priority": 51,
+      "priority": 50,
       "categories": [
+        "starters",
         "gen-ai"
       ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
       "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-python",
+      "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-javascript",
       "folderPath": ".",
-      "gitRef": "refs/heads/main",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ]
-    },
-    {
-      "id": "mcp-sdk-hosting-typescript",
-      "displayName": "Self-hosted MCP SDK Server (TypeScript + AZD + Bicep)",
-      "shortDescription": "Hosts MCP SDK tools on Azure Functions via HttpTrigger wrapper",
-      "longDescription": "TypeScript Azure Functions app using HttpTrigger as the transport layer to host MCP SDK protocol tools. The HTTP trigger serves as the entry point for MCP protocol requests.",
-      "language": "TypeScript",
-      "bindingType": "trigger",
-      "resource": "MCP",
-      "iac": "bicep",
-      "priority": 51,
-      "categories": [
-        "gen-ai"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-node",
-      "folderPath": ".",
-      "gitRef": "refs/heads/main",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ]
-    },
-    {
-      "id": "mcp-sdk-hosting-java",
-      "displayName": "Self-hosted MCP SDK Server (Java + AZD + Bicep)",
-      "shortDescription": "Hosts MCP tools using Quarkus framework and MCP SDK",
-      "longDescription": "Java application built on the Quarkus framework hosting MCP protocol tools (weather) using the MCP SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "MCP",
-      "iac": "bicep",
-      "priority": 51,
-      "categories": [
-        "gen-ai"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-java",
-      "folderPath": ".",
-      "gitRef": "refs/heads/main",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
+        "MCP Tool trigger functions",
+        "Snippet save/retrieve tools with Blob storage",
+        "Microsoft Entra ID authentication",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Weather app with interactive Vite UI",
+        "VS Code mcp.json configuration",
+        "MCP Inspector support",
+        "Dev Container setup"
       ]
     },
     {
@@ -1782,8 +1689,8 @@
     {
       "id": "ai-serverless-agents-python",
       "displayName": "Serverless Agents (Python + AZD + Bicep)",
-      "shortDescription": "Markdown-first serverless agents with chat, timer trigger, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook MCP tools",
-      "longDescription": "Python Azure Functions app using the Azure Functions serverless agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
+      "shortDescription": "Markdown-first serverless agents with chat, timer trigger, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools, deployed via azd",
+      "longDescription": "Build and deploy serverless agents on Azure Functions in Python using the Azure Functions serverless agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
       "language": "Python",
       "bindingType": "trigger",
       "resource": "http",
@@ -2544,6 +2451,189 @@
         "requirements.txt",
         "README.md"
       ]
+    },
+    {
+      "id": "office365-connector-trigger-csharp",
+      "displayName": "Office 365 Outlook Connector Triggers (C# + AZD + Bicep)",
+      "shortDescription": "Office 365 Outlook email and calendar connector triggers with Blob output, deployed via azd",
+      "longDescription": "Build and deploy an Office 365 Outlook connector app on Azure Functions in C#. This app provides five connector trigger functions, each receiving a different Outlook event type from the Connector Namespace via ConnectorTrigger and writing the payload to Blob storage with BlobOutput: (1) OnNewEmail for incoming mail, (2) OnFlaggedEmail for flagged mail, (3) OnNewMentionMeEmail for mail that mentions you, (4) OnNewCalendarEvent for newly created calendar items, and (5) OnUpcomingEvent for upcoming calendar events. Built on the Azure.Connectors.Sdk and the Microsoft.Azure.Functions.Worker.Extensions.Connector worker extension. Runs on Flex Consumption (.NET 10 isolated) with a user-assigned managed identity and an OAuth Office 365 Outlook connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "CSharp",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 80,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-net",
+      "folderPath": "office365App",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (OnNewEmail, OnFlaggedEmail, OnNewMentionMeEmail, OnNewCalendarEvent, OnUpcomingEvent)",
+        "ConnectorTrigger bindings with BlobOutput payload storage",
+        "OAuth Office 365 Outlook connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "VS Code configuration"
+      ]
+    },
+    {
+      "id": "office365-connector-trigger-typescript",
+      "displayName": "Office 365 Outlook Connector Triggers (TypeScript + AZD + Bicep)",
+      "shortDescription": "Office 365 Outlook email and calendar connector triggers, deployed via azd",
+      "longDescription": "Build and deploy an Office 365 Outlook connector app on Azure Functions in TypeScript. This app provides five connector trigger functions, each receiving a different Outlook event type from the Connector Namespace via the connector trigger and logging the received payload: (1) onNewEmail for incoming mail, (2) onFlaggedEmail for flagged mail, (3) onNewMentionMeEmail for mail that mentions you, (4) onNewCalendarEvent for newly created calendar items, and (5) onUpcomingEvent for upcoming calendar events. Built on the Azure Functions Connector trigger extension. Runs on Flex Consumption with a user-assigned managed identity and an OAuth Office 365 Outlook connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "TypeScript",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 80,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-typescript",
+      "folderPath": "office365App",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (onNewEmail, onFlaggedEmail, onNewMentionMeEmail, onNewCalendarEvent, onUpcomingEvent)",
+        "Connector triggers that log the received payload",
+        "OAuth Office 365 Outlook connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "TypeScript project files (package.json, tsconfig.json)"
+      ]
+    },
+    {
+      "id": "office365-connector-trigger-python",
+      "displayName": "Office 365 Outlook Connector Triggers (Python + AZD + Bicep)",
+      "shortDescription": "Office 365 Outlook email and calendar connector triggers, deployed via azd",
+      "longDescription": "Build and deploy an Office 365 Outlook connector app on Azure Functions in Python. This app provides five connector trigger functions, each receiving a different Outlook event type from the Connector Namespace via the connector_trigger decorator and logging the received payload: (1) OnNewEmail for incoming mail, (2) OnFlaggedEmail for flagged mail, (3) OnNewMentionMeEmail for mail that mentions you, (4) OnNewCalendarEvent for newly created calendar items, and (5) OnUpcomingEvent for upcoming calendar events. Built on the Azure Functions Connector trigger extension. Runs on Flex Consumption with a user-assigned managed identity and an OAuth Office 365 Outlook connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 80,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-python",
+      "folderPath": "office365App",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (OnNewEmail, OnFlaggedEmail, OnNewMentionMeEmail, OnNewCalendarEvent, OnUpcomingEvent)",
+        "Connector triggers that log the received payload",
+        "OAuth Office 365 Outlook connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "Python project files (function_app.py, requirements.txt)"
+      ]
+    },
+    {
+      "id": "sharepoint-connector-trigger-csharp",
+      "displayName": "SharePoint Online Connector Triggers (C# + AZD + Bicep)",
+      "shortDescription": "SharePoint Online file connector triggers with Blob output, deployed via azd",
+      "longDescription": "Build and deploy a SharePoint Online connector app on Azure Functions in C#. This app provides two connector trigger functions, each receiving a different SharePoint Online file event from the Connector Namespace via ConnectorTrigger and writing the payload to Blob storage with BlobOutput: (1) OnNewFile for newly added files and (2) OnUpdatedFile for updated files. Built on the Azure.Connectors.Sdk and the Microsoft.Azure.Functions.Worker.Extensions.Connector worker extension. Runs on Flex Consumption (.NET 10 isolated) with a user-assigned managed identity and an OAuth SharePoint Online connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "CSharp",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 81,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-net",
+      "folderPath": "sharepointApp",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (OnNewFile, OnUpdatedFile)",
+        "ConnectorTrigger bindings with BlobOutput payload storage",
+        "OAuth SharePoint Online connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "host.json and project files"
+      ],
+      "isHighlighted": true
+    },
+    {
+      "id": "sharepoint-connector-trigger-typescript",
+      "displayName": "SharePoint Online Connector Triggers (TypeScript + AZD + Bicep)",
+      "shortDescription": "SharePoint Online file connector triggers, deployed via azd",
+      "longDescription": "Build and deploy a SharePoint Online connector app on Azure Functions in TypeScript. This app provides two connector trigger functions, each receiving a different SharePoint Online file event from the Connector Namespace via the connector trigger and logging the received payload: (1) onSharepointNewFile for newly added files and (2) onSharepointUpdatedFile for updated files. Built on the Azure Functions Connector trigger extension. Runs on Flex Consumption with a user-assigned managed identity and an OAuth SharePoint Online connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "TypeScript",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 81,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-typescript",
+      "folderPath": "sharepointApp",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (onSharepointNewFile, onSharepointUpdatedFile)",
+        "Connector triggers that log the received payload",
+        "OAuth SharePoint Online connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "TypeScript project files (package.json, tsconfig.json)"
+      ],
+      "isHighlighted": true
+    },
+    {
+      "id": "sharepoint-connector-trigger-python",
+      "displayName": "SharePoint Online Connector Triggers (Python + AZD + Bicep)",
+      "shortDescription": "SharePoint Online file connector triggers, deployed via azd",
+      "longDescription": "Build and deploy a SharePoint Online connector app on Azure Functions in Python. This app provides two connector trigger functions, each receiving a different SharePoint Online file event from the Connector Namespace via the connector_trigger decorator and logging the received payload: (1) OnSharepointNewFile for newly added files and (2) OnSharepointUpdatedFile for updated files. Built on the Azure Functions Connector trigger extension. Runs on Flex Consumption with a user-assigned managed identity and an OAuth SharePoint Online connection authorized via a post-deploy hook. Deployed with azd.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "connector",
+      "iac": "bicep",
+      "priority": 81,
+      "categories": [
+        "starters",
+        "connectors",
+        "event-processing"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-connectors-python",
+      "folderPath": "sharepointApp",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Connector trigger functions (OnSharepointNewFile, OnSharepointUpdatedFile)",
+        "Connector triggers that log the received payload",
+        "OAuth SharePoint Online connection",
+        "Post-deploy connection authorization scripts",
+        "User-assigned managed identity",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration (azure.yaml)",
+        "Python project files (function_app.py, requirements.txt)"
+      ],
+      "isHighlighted": true
     }
   ]
 }

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-06-30T21:06:27Z",
+  "generatedAt": "2026-06-30T22:13:05Z",
   "version": "1.9.0",
-  "totalTemplates": 77,
+  "totalTemplates": 75,
   "runtimeVersions": {
     "Python": {
       "supported": [
@@ -1859,74 +1859,6 @@
         "Azure Developer CLI (azd) configuration",
         "Dev Container setup",
         "Test files with sample prompts"
-      ]
-    },
-    {
-      "id": "ai-textsummarize-csharp",
-      "displayName": "Text Summarization using AI (C# + AZD + Bicep)",
-      "shortDescription": "Summarizes text documents using Azure AI Language, EventGrid-sourced BlobTrigger with BlobOutput",
-      "longDescription": "C# Azure Function with a BlobTrigger (EventGrid event source) that reads text documents from Azure Blob Storage, summarizes them using the Azure AI Language (TextAnalytics) service, and writes the summary to an output blob via BlobOutput binding.",
-      "language": "CSharp",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 62,
-      "categories": [
-        "gen-ai"
-      ],
-      "tags": [
-        "AI",
-        "Cognitive Services",
-        "Blob",
-        "Summarization"
-      ],
-      "author": "Paul Yuknewicz",
-      "repositoryUrl": "https://github.com/Azure-Samples/function-csharp-ai-textsummarize",
-      "folderPath": ".",
-      "gitRef": "refs/tags/v1.0.0",
-      "whatsIncluded": [
-        "Blob trigger function",
-        "Azure Cognitive Services integration",
-        "Text summarization processing",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "Sample text documents",
-        "VS Code debug configuration",
-        "Dev Container setup"
-      ]
-    },
-    {
-      "id": "ai-textsummarize-python",
-      "displayName": "Text Summarization using AI (Python + AZD + Bicep)",
-      "shortDescription": "Summarizes text documents using Azure AI Language, EventGrid-sourced BlobTrigger with BlobOutput",
-      "longDescription": "Python Azure Function with a BlobTrigger (EventGrid event source) that reads text documents from Azure Blob Storage, summarizes them using the Azure AI Language (TextAnalytics) service, and writes the summary to an output blob via BlobOutput binding.",
-      "language": "Python",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 62,
-      "categories": [
-        "gen-ai"
-      ],
-      "tags": [
-        "AI",
-        "Cognitive Services",
-        "Blob",
-        "Summarization"
-      ],
-      "author": "Paul Yuknewicz",
-      "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-textsummarize",
-      "folderPath": ".",
-      "gitRef": "refs/heads/main",
-      "whatsIncluded": [
-        "Blob trigger function",
-        "Azure Cognitive Services integration",
-        "Text summarization processing",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "Sample text documents",
-        "VS Code debug configuration",
-        "Dev Container setup"
       ]
     },
     {

--- a/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
+++ b/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
@@ -45,7 +45,8 @@
           "PowerShell",
           "Python",
           "Terraform",
-          "TypeScript"
+          "TypeScript",
+          "Go"
         ]
       },
       "description": "List of supported programming languages"
@@ -73,6 +74,7 @@
         "id",
         "displayName",
         "shortDescription",
+        "longDescription",
         "language",
         "bindingType",
         "resource",
@@ -80,7 +82,8 @@
         "priority",
         "categories",
         "repositoryUrl",
-        "folderPath"
+        "folderPath",
+        "gitRef"
       ],
       "properties": {
         "id": {
@@ -144,6 +147,7 @@
             "mysql",
             "signalr",
             "rabbitmq",
+            "connector",
             "MCP",
             "durable",
             "generic"


### PR DESCRIPTION
## Description

Adds new Azure Functions samples to the Template Manifest, removes samples whose source repos were archived, refreshes language runtime versions, and documents the process via a new Copilot skill.

- **Runtime versions:** updated `runtimeVersions` to the latest supported levels (Node.js 24 GA + dropped EOL Node 20, Java default 17). Added a new **Go** entry (preview 1.24).
- **New samples:**
  - Office 365 Outlook connector triggers (C#, TypeScript, Python) — P80
  - SharePoint Online connector triggers (C#, TypeScript, Python) — P81
  - JavaScript remote MCP server — completes the P50 MCP family
- **Removed (archived source repos):**
  - `mcp-sdk-hosting-*` (C#/Python/TS/Java) — `Azure-Samples/mcp-sdk-functions-hosting-{dotnet,python,node,java}`
  - `ai-textsummarize-csharp` — `Azure-Samples/function-csharp-ai-textsummarize`
  - `ai-textsummarize-python` — `Azure-Samples/function-python-ai-textsummarize`
- **Schema:** added `connector` to the `resource` enum.
- **Metadata:** `version` 1.8.0 → 1.9.0, `totalTemplates` → 75, refreshed `generatedAt`.
- **Docs:** `docs/priority-tiers.md` synced (listing, block map, coverage matrix, summary, totals) including a "Removed (archived repos)" note.
- **Skill:** added `.github/skills/add-manifest-sample` documenting how to add a sample to the manifest.

## Related issues

- Related to Azure/azure-functions-bucees-planning#1054
- Related to Azure/azure-functions-bucees-planning#1055
- Related to Azure/azure-functions-bucees-planning#916

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [ ] Or: only updating an existing template

> N/A — these are manifest-based samples (no `.nuspec`/`Resources.resx` template payloads added).

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [x] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [x] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [x] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
