### PR TITLE
Surface Go quickstarts in the Functions template manifest

### DIFF
--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,6 +1,6 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
-**Total templates:** 78
+**Total templates:** 79
 **Manifest version:** 1.10.0
 
 ## Design principles
@@ -8,7 +8,7 @@
 1. **Priority is the primary sort key.** Lower number = show first.
 2. **5-slot blocks per Azure resource:** `+0` trigger, `+1` input, `+2` output, `+3` variant, `+4` stub.
 3. **10-slot block for MCP:** `+0` Remote Server, `+1` SDK Hosting, `+2` Tool, `+3` Resource, `+4` Prompt, `+5` APIM Gateway.
-4. **Language sort order (secondary):** .NET (C#) → Python → TypeScript → JavaScript → Java → PowerShell → Go.
+4. **Language sort order (secondary):** .NET (C#) → Python → TypeScript → JavaScript → Java → Go → PowerShell.
    Templates sharing a priority are sorted by this language order by the consumer.
 5. **IaC sort order (tertiary):** 🚧 no AZD → ✅ AZD → 📦 IaC-only.
    no AZD = what VS Code Azure Functions extension generates = the familiar baseline.
@@ -39,7 +39,7 @@
 
 ## Full template listing
 
-Sorted by priority → language order (.NET → Py → TS → JS → Java → PS → Go).
+Sorted by priority → language order (.NET → Py → TS → JS → Java → Go → PS).
 
 | P | Template ID | Lang | Binding | IaC | Was |
 |--:|---|---|---|---|---|
@@ -49,8 +49,8 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 0 | `http-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0 |
 | 0 | `http-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0 |
 | 0 | `http-trigger-java-azd` | Java | trigger | ✅ bicep | P0 |
-| 0 | `http-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0 |
 | 0 | `http-trigger-go-azd` | Go | trigger | ✅ bicep | *new* |
+| 0 | `http-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0 |
 | 3 | `http-trigger-csharp-terraform` | .NET | trigger | 📦 terraform | P0→3 |
 | | **⏰ Timer** | | | | |
 | 5 | `timer-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→5 |
@@ -58,6 +58,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 5 | `timer-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0→5 |
 | 5 | `timer-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0→5 |
 | 5 | `timer-trigger-java-azd` | Java | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-go-azd` | Go | trigger | ✅ bicep | *new* |
 | 5 | `timer-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0→5 |
 | | **📦 Blob Storage** | | | | |
 | 10 | `blob-eventgrid-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→10 |
@@ -160,58 +161,58 @@ These templates were removed because their source repositories were **archived**
 
 ### Azure resource templates (P00–P44)
 
-| Resource | Binding | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+| Resource | Binding | .NET | Py | TS | JS | Java | Go | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|---|
 | HTTP | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Timer | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
-| Blob | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
-| | Input | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | *no dedicated templates yet* |
+| Timer | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Blob | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | Go |
+| | Input | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | 🔗+🚧 | *no dedicated templates yet* |
 | | Output | — | — | — | — | — | — | — | *no dedicated templates yet* |
-| Event Hub | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| Event Hub | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | Go |
 | | Output | — | 🔗+🚧 | 🔗+🚧 | — | — | — | — | *no dedicated templates yet* |
 | Event Grid | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
 | Queue | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
-| Service Bus | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
-| Cosmos DB | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| Service Bus | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | Go |
+| Cosmos DB | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | Go |
 | | Input | — | — | — | — | — | — | — | *no dedicated templates yet* |
 | | Output | — | — | — | — | — | — | — | *no dedicated templates yet* |
-| SQL | Trigger | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
+| SQL | Trigger | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, Go, PS |
 | | Input | — | — | — | — | — | — | — | *no dedicated templates yet* |
 | | Output | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | — | — | — | *no dedicated templates yet* |
 | Redis | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
 
 ### MCP templates (P50–P59)
 
-| Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+| Sub-type | P | .NET | Py | TS | JS | Java | Go | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|---|
-| Remote Server | P50 | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | PS |
+| Remote Server | P50 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | PS |
 | SDK Hosting | P51 | — | — | — | — | — | — | — | *removed (repos archived)* |
 | Tool | P52 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | — | *no dedicated templates yet* |
 | Resource | P53 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | — | *no dedicated templates yet* |
 | Prompt | P54 | 🔗 | — | — | — | — | — | — | *no dedicated templates yet* |
-| APIM Gateway | P55 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, PS, Go |
+| APIM Gateway | P55 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, Go, PS |
 
 ### AI · Durable · Agent Framework (P60–P79)
 
-| Category | Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+| Category | Sub-type | P | .NET | Py | TS | JS | Java | Go | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|---|---|
-| AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | — | JS, PS, Go |
-|  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | — | .NET, TS, Java, PS, Go |
+| AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | — | JS, Go, PS |
+|  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | — | .NET, TS, Java, Go, PS |
 |  | Text Summarize | P62 | — | — | — | — | — | — | — | *removed (repos archived)* |
-|  | LangChain | P63 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, PS, Go |
-| Durable | Orchestration | P65 | ✅ | ✅ | ✅ | 🚧 | — | — | — | Java, PS, Go |
-|  | Order Processor | P66 | ✅ | ✅ | — | — | — | — | — | TS, JS, Java, PS, Go |
-|  | Patterns | P70 | ✅ | — | — | — | — | — | — | Py, TS, JS, Java, PS, Go |
-|  | Scenarios | P71 | 🚧 | — | — | — | — | — | — | Py, TS, JS, Java, PS, Go |
-|  | PDF Summarizer | P72 | 🚧 | 🚧 | — | — | — | — | — | TS, JS, Java, PS, Go |
-| Agent Fw | Multi-Agent | P75 | — | 🚧 | — | — | — | — | ✅ | .NET, TS, JS, Java, PS |
+|  | LangChain | P63 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, Go, PS |
+| Durable | Orchestration | P65 | ✅ | ✅ | ✅ | 🚧 | — | — | — | Java, Go, PS |
+|  | Order Processor | P66 | ✅ | ✅ | — | — | — | — | — | TS, JS, Java, Go, PS |
+|  | Patterns | P70 | ✅ | — | — | — | — | — | — | Py, TS, JS, Java, Go, PS |
+|  | Scenarios | P71 | 🚧 | — | — | — | — | — | — | Py, TS, JS, Java, Go, PS |
+|  | PDF Summarizer | P72 | 🚧 | 🚧 | — | — | — | — | — | TS, JS, Java, Go, PS |
+| Agent Fw | Multi-Agent | P75 | — | 🚧 | — | — | — | ✅ | — | .NET, TS, JS, Java, PS |
 
 ### Connectors (P80–P89)
 
-| Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+| Sub-type | P | .NET | Py | TS | JS | Java | Go | PS | Gaps |
 |---|---|---|---|---|---|---|---|---|---|
-| Office 365 Outlook | P80 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
-| SharePoint Online | P81 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
+| Office 365 Outlook | P80 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, Go, PS |
+| SharePoint Online | P81 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, Go, PS |
 
 ## Summary
 
@@ -219,7 +220,7 @@ These templates were removed because their source repositories were **archived**
 |--:|---|--:|
 | 00 | ⚡ HTTP — Trigger | 7 |
 | 03 | ⚡ HTTP — Variant (Terraform) | 1 |
-| 05 | ⏰ Timer — Trigger | 6 |
+| 05 | ⏰ Timer — Trigger | 7 |
 | 10 | 🪣 Blob Storage — Trigger | 6 |
 | 15 | 📡 Event Hub — Trigger | 6 |
 | 30 | 🚌 Service Bus — Trigger | 6 |
@@ -238,7 +239,7 @@ These templates were removed because their source repositories were **archived**
 | 75 | 🤝 Agent Framework — Multi-Agent | 2 |
 | 80 | 🔌 Connectors — Office 365 Outlook | 3 |
 | 81 | 🔌 Connectors — SharePoint Online | 3 |
-| | **Total** | **78** |
+| | **Total** | **79** |
 
 ## Language sort order
 
@@ -251,8 +252,8 @@ When templates share the same priority, sort by:
 | 3 | TypeScript | Modern JS with types |
 | 4 | JavaScript | Broad web developer reach |
 | 5 | Java | Enterprise |
-| 6 | PowerShell | IT automation / scripting |
-| 7 | Go | Cloud-native services and tooling |
+| 6 | Go | Cloud-native services and tooling |
+| 7 | PowerShell | IT automation / scripting |
 
 ## Schema change required
 

--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,14 +1,14 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
-**Total templates:** 75
-**Manifest version:** 1.9.0
+**Total templates:** 78
+**Manifest version:** 1.10.0
 
 ## Design principles
 
 1. **Priority is the primary sort key.** Lower number = show first.
 2. **5-slot blocks per Azure resource:** `+0` trigger, `+1` input, `+2` output, `+3` variant, `+4` stub.
 3. **10-slot block for MCP:** `+0` Remote Server, `+1` SDK Hosting, `+2` Tool, `+3` Resource, `+4` Prompt, `+5` APIM Gateway.
-4. **Language sort order (secondary):** .NET (C#) → Python → TypeScript → JavaScript → Java → PowerShell.
+4. **Language sort order (secondary):** .NET (C#) → Python → TypeScript → JavaScript → Java → PowerShell → Go.
    Templates sharing a priority are sorted by this language order by the consumer.
 5. **IaC sort order (tertiary):** 🚧 no AZD → ✅ AZD → 📦 IaC-only.
    no AZD = what VS Code Azure Functions extension generates = the familiar baseline.
@@ -39,7 +39,7 @@
 
 ## Full template listing
 
-Sorted by priority → language order (.NET → Py → TS → JS → Java → PS).
+Sorted by priority → language order (.NET → Py → TS → JS → Java → PS → Go).
 
 | P | Template ID | Lang | Binding | IaC | Was |
 |--:|---|---|---|---|---|
@@ -50,6 +50,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 0 | `http-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0 |
 | 0 | `http-trigger-java-azd` | Java | trigger | ✅ bicep | P0 |
 | 0 | `http-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-go-azd` | Go | trigger | ✅ bicep | *new* |
 | 3 | `http-trigger-csharp-terraform` | .NET | trigger | 📦 terraform | P0→3 |
 | | **⏰ Timer** | | | | |
 | 5 | `timer-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→5 |
@@ -96,6 +97,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 50 | `mcp-server-remote-typescript` | TS | trigger | ✅ bicep | P0→50 |
 | 50 | `mcp-server-remote-javascript` | JS | trigger | ✅ bicep | *new* |
 | 50 | `mcp-server-remote-java` | Java | trigger | ✅ bicep | P0→50 |
+| 50 | `mcp-server-remote-go` | Go | trigger | ✅ bicep | *new* |
 | 55 | `mcp-server-apim-python` | Py | trigger | ✅ bicep | P2→55 |
 | | **🤖 AI** | | | | |
 | 60 | `ai-agent-csharp` | .NET | trigger | ✅ bicep | P0→60 |
@@ -124,6 +126,7 @@ Sorted by priority → language order (.NET → Py → TS → JS → Java → PS
 | 72 | `durable-pdf-summarizer-python` | Py | orchestration | 🚧 none | P2→72 |
 | | **🤝 Agent Framework** | | | | |
 | 75 | `agentframework-durable-multi-agent-python` | Py | orchestration | 🚧 none | P1→75 |
+| 75 | `agentframework-multi-agent-go` | Go | trigger | ✅ bicep | *new* |
 | | **🔌 Connectors** | | | | |
 | 80 | `office365-connector-trigger-csharp` | .NET | trigger | ✅ bicep | *new* |
 | 80 | `office365-connector-trigger-python` | Py | trigger | ✅ bicep | *new* |
@@ -157,64 +160,64 @@ These templates were removed because their source repositories were **archived**
 
 ### Azure resource templates (P00–P44)
 
-| Resource | Binding | .NET | Py | TS | JS | Java | PS | Gaps |
-|---|---|---|---|---|---|---|---|---|
-| HTTP | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Timer | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Blob | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| | Input | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | *no dedicated templates yet* |
-| | Output | — | — | — | — | — | — | *no dedicated templates yet* |
-| Event Hub | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| | Output | — | 🔗+🚧 | 🔗+🚧 | — | — | — | *no dedicated templates yet* |
-| Event Grid | *(reserved)* | — | — | — | — | — | — | *no dedicated templates yet* |
-| Queue | *(reserved)* | — | — | — | — | — | — | *no dedicated templates yet* |
-| Service Bus | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Cosmos DB | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| | Input | — | — | — | — | — | — | *no dedicated templates yet* |
-| | Output | — | — | — | — | — | — | *no dedicated templates yet* |
-| SQL | Trigger | ✅ | ✅ | ✅ | — | — | — | JS, Java, PS |
-| | Input | — | — | — | — | — | — | *no dedicated templates yet* |
-| | Output | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | — | — | *no dedicated templates yet* |
-| Redis | *(reserved)* | — | — | — | — | — | — | *no dedicated templates yet* |
+| Resource | Binding | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+|---|---|---|---|---|---|---|---|---|---|
+| HTTP | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Timer | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| Blob | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| | Input | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | *no dedicated templates yet* |
+| | Output | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| Event Hub | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| | Output | — | 🔗+🚧 | 🔗+🚧 | — | — | — | — | *no dedicated templates yet* |
+| Event Grid | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| Queue | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| Service Bus | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| Cosmos DB | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | Go |
+| | Input | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| | Output | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| SQL | Trigger | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
+| | Input | — | — | — | — | — | — | — | *no dedicated templates yet* |
+| | Output | 🔗+🚧 | 🔗+🚧 | 🔗+🚧 | — | — | — | — | *no dedicated templates yet* |
+| Redis | *(reserved)* | — | — | — | — | — | — | — | *no dedicated templates yet* |
 
 ### MCP templates (P50–P59)
 
-| Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
-|---|---|---|---|---|---|---|---|---|
-| Remote Server | P50 | ✅ | ✅ | ✅ | ✅ | ✅ | — | PS |
-| SDK Hosting | P51 | — | — | — | — | — | — | *removed (repos archived)* |
-| Tool | P52 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | *no dedicated templates yet* |
-| Resource | P53 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | *no dedicated templates yet* |
-| Prompt | P54 | 🔗 | — | — | — | — | — | *no dedicated templates yet* |
-| APIM Gateway | P55 | — | ✅ | — | — | — | — | .NET, TS, JS, Java, PS |
+| Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+|---|---|---|---|---|---|---|---|---|---|
+| Remote Server | P50 | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | PS |
+| SDK Hosting | P51 | — | — | — | — | — | — | — | *removed (repos archived)* |
+| Tool | P52 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | — | *no dedicated templates yet* |
+| Resource | P53 | 🔗 | 🔗 | 🔗 | — | 🔗 | — | — | *no dedicated templates yet* |
+| Prompt | P54 | 🔗 | — | — | — | — | — | — | *no dedicated templates yet* |
+| APIM Gateway | P55 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, PS, Go |
 
 ### AI · Durable · Agent Framework (P60–P79)
 
-| Category | Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
-|---|---|---|---|---|---|---|---|---|---|
-| AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | JS, PS |
-|  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | .NET, TS, Java, PS |
-|  | Text Summarize | P62 | — | — | — | — | — | — | *removed (repos archived)* |
-|  | LangChain | P63 | — | ✅ | — | — | — | — | .NET, TS, JS, Java, PS |
-| Durable | Orchestration | P65 | ✅ | ✅ | ✅ | 🚧 | — | — | Java, PS |
-|  | Order Processor | P66 | ✅ | ✅ | — | — | — | — | TS, JS, Java, PS |
-|  | Patterns | P70 | ✅ | — | — | — | — | — | Py, TS, JS, Java, PS |
-|  | Scenarios | P71 | 🚧 | — | — | — | — | — | Py, TS, JS, Java, PS |
-|  | PDF Summarizer | P72 | 🚧 | 🚧 | — | — | — | — | TS, JS, Java, PS |
-| Agent Fw | Multi-Agent | P75 | — | 🚧 | — | — | — | — | .NET, TS, JS, Java, PS |
+| Category | Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+|---|---|---|---|---|---|---|---|---|---|---|
+| AI | Agent | P60 | ✅ | ✅ (2) | ✅ | — | ✅ | — | — | JS, PS, Go |
+|  | ChatGPT | P61 | — | ✅ | — | ✅ | — | — | — | .NET, TS, Java, PS, Go |
+|  | Text Summarize | P62 | — | — | — | — | — | — | — | *removed (repos archived)* |
+|  | LangChain | P63 | — | ✅ | — | — | — | — | — | .NET, TS, JS, Java, PS, Go |
+| Durable | Orchestration | P65 | ✅ | ✅ | ✅ | 🚧 | — | — | — | Java, PS, Go |
+|  | Order Processor | P66 | ✅ | ✅ | — | — | — | — | — | TS, JS, Java, PS, Go |
+|  | Patterns | P70 | ✅ | — | — | — | — | — | — | Py, TS, JS, Java, PS, Go |
+|  | Scenarios | P71 | 🚧 | — | — | — | — | — | — | Py, TS, JS, Java, PS, Go |
+|  | PDF Summarizer | P72 | 🚧 | 🚧 | — | — | — | — | — | TS, JS, Java, PS, Go |
+| Agent Fw | Multi-Agent | P75 | — | 🚧 | — | — | — | — | ✅ | .NET, TS, JS, Java, PS |
 
 ### Connectors (P80–P89)
 
-| Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
-|---|---|---|---|---|---|---|---|---|
-| Office 365 Outlook | P80 | ✅ | ✅ | ✅ | — | — | — | JS, Java, PS |
-| SharePoint Online | P81 | ✅ | ✅ | ✅ | — | — | — | JS, Java, PS |
+| Sub-type | P | .NET | Py | TS | JS | Java | PS | Go | Gaps |
+|---|---|---|---|---|---|---|---|---|---|
+| Office 365 Outlook | P80 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
+| SharePoint Online | P81 | ✅ | ✅ | ✅ | — | — | — | — | JS, Java, PS, Go |
 
 ## Summary
 
 | P | Slot label | Templates |
 |--:|---|--:|
-| 00 | ⚡ HTTP — Trigger | 6 |
+| 00 | ⚡ HTTP — Trigger | 7 |
 | 03 | ⚡ HTTP — Variant (Terraform) | 1 |
 | 05 | ⏰ Timer — Trigger | 6 |
 | 10 | 🪣 Blob Storage — Trigger | 6 |
@@ -222,7 +225,7 @@ These templates were removed because their source repositories were **archived**
 | 30 | 🚌 Service Bus — Trigger | 6 |
 | 35 | 🌐 Cosmos DB — Trigger | 6 |
 | 40 | 🗄️ SQL — Trigger | 3 |
-| 50 | 🔌 MCP — Remote Server | 5 |
+| 50 | 🔌 MCP — Remote Server | 6 |
 | 55 | 🔌 MCP — APIM Gateway | 1 |
 | 60 | 🤖 AI — Agent | 5 |
 | 61 | 🤖 AI — ChatGPT | 2 |
@@ -232,10 +235,10 @@ These templates were removed because their source repositories were **archived**
 | 70 | 🔄 Durable Advanced — Patterns (saga / tracing / payload) | 4 |
 | 71 | 🔄 Durable Advanced — Scenarios (travel / aspire) | 2 |
 | 72 | 🔄 Durable Advanced — PDF Summarizer | 2 |
-| 75 | 🤝 Agent Framework — Multi-Agent | 1 |
+| 75 | 🤝 Agent Framework — Multi-Agent | 2 |
 | 80 | 🔌 Connectors — Office 365 Outlook | 3 |
 | 81 | 🔌 Connectors — SharePoint Online | 3 |
-| | **Total** | **75** |
+| | **Total** | **78** |
 
 ## Language sort order
 
@@ -249,6 +252,7 @@ When templates share the same priority, sort by:
 | 4 | JavaScript | Broad web developer reach |
 | 5 | Java | Enterprise |
 | 6 | PowerShell | IT automation / scripting |
+| 7 | Go | Cloud-native services and tooling |
 
 ## Schema change required
 

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-07-30T18:16:05Z",
+  "generatedAt": "2026-08-06T17:33:17Z",
   "version": "1.10.0",
-  "totalTemplates": 78,
+  "totalTemplates": 79,
   "runtimeVersions": {
     "Python": {
       "supported": [
@@ -250,6 +250,33 @@
       ]
     },
     {
+      "id": "http-trigger-go-azd",
+      "displayName": "HTTP Trigger (Go + AZD + Bicep)",
+      "shortDescription": "Accepts GET and POST requests on Flex Consumption with managed identity and optional VNet, deployed via azd",
+      "longDescription": "Build and deploy an Azure Functions app in Go with two HttpTrigger functions: (1) httpget accepts GET requests and returns a greeting, and (2) httppost validates a JSON name and age payload and returns a personalized response. Runs on Flex Consumption with managed identity and optional VNet integration. Deployed with azd.",
+      "language": "Go",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 0,
+      "categories": [
+        "starters",
+        "web-apis"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-go-azd",
+      "folderPath": ".",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "HTTP GET and POST trigger functions",
+        "Native Go worker configuration",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Managed identity and optional VNet integration",
+        "VS Code debug configuration"
+      ]
+    },
+    {
       "id": "http-trigger-powershell-azd",
       "displayName": "HTTP Trigger (PowerShell + AZD + Bicep)",
       "shortDescription": "Flex Consumption with managed identity and VNet, deployed via azd",
@@ -280,33 +307,6 @@
         "Azure Developer CLI (azd) configuration",
         "VS Code debug configuration",
         "Test files for local development"
-      ]
-    },
-    {
-      "id": "http-trigger-go-azd",
-      "displayName": "HTTP Trigger (Go + AZD + Bicep)",
-      "shortDescription": "Accepts GET and POST requests on Flex Consumption with managed identity and optional VNet, deployed via azd",
-      "longDescription": "Build and deploy an Azure Functions app in Go with two HttpTrigger functions: (1) httpget accepts GET requests and returns a greeting, and (2) httppost validates a JSON name and age payload and returns a personalized response. Runs on Flex Consumption with managed identity and optional VNet integration. Deployed with azd.",
-      "language": "Go",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "starters",
-        "web-apis"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-go-azd",
-      "folderPath": ".",
-      "gitRef": "refs/tags/v1.0.0",
-      "whatsIncluded": [
-        "HTTP GET and POST trigger functions",
-        "Native Go worker configuration",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "Managed identity and optional VNet integration",
-        "VS Code debug configuration"
       ]
     },
     {
@@ -507,6 +507,34 @@
         "azd configuration",
         "VNet integration option",
         "Dev Container setup"
+      ]
+    },
+    {
+      "id": "timer-trigger-go-azd",
+      "displayName": "Timer Trigger (Go + AZD + Bicep)",
+      "shortDescription": "Native Go timer running every 30 minutes on Flex Consumption with optional VNet, deployed via azd",
+      "longDescription": "Build and deploy an Azure Functions app in Go with a scheduledTask TimerTrigger that runs every 30 minutes and logs schedule, invocation, and retry details. Uses the native Go worker and runs on Flex Consumption with managed identity and optional VNet integration. Deployed with azd.",
+      "language": "Go",
+      "bindingType": "trigger",
+      "resource": "timer",
+      "iac": "bicep",
+      "priority": 5,
+      "categories": [
+        "starters"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-go-azd-timer",
+      "folderPath": ".",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "scheduledTask timer trigger function",
+        "Native Go worker configuration",
+        "30-minute NCRONTAB schedule",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Managed identity and optional VNet integration",
+        "VS Code debug configuration",
+        "Test files for local development"
       ]
     },
     {

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-06-30T22:13:05Z",
-  "version": "1.9.0",
-  "totalTemplates": 75,
+  "generatedAt": "2026-07-30T18:16:05Z",
+  "version": "1.10.0",
+  "totalTemplates": 78,
   "runtimeVersions": {
     "Python": {
       "supported": [
@@ -70,6 +70,7 @@
   },
   "languages": [
     "CSharp",
+    "Go",
     "Java",
     "JavaScript",
     "PowerShell",
@@ -279,6 +280,33 @@
         "Azure Developer CLI (azd) configuration",
         "VS Code debug configuration",
         "Test files for local development"
+      ]
+    },
+    {
+      "id": "http-trigger-go-azd",
+      "displayName": "HTTP Trigger (Go + AZD + Bicep)",
+      "shortDescription": "Accepts GET and POST requests on Flex Consumption with managed identity and optional VNet, deployed via azd",
+      "longDescription": "Build and deploy an Azure Functions app in Go with two HttpTrigger functions: (1) httpget accepts GET requests and returns a greeting, and (2) httppost validates a JSON name and age payload and returns a personalized response. Runs on Flex Consumption with managed identity and optional VNet integration. Deployed with azd.",
+      "language": "Go",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 0,
+      "categories": [
+        "starters",
+        "web-apis"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-go-azd",
+      "folderPath": ".",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "HTTP GET and POST trigger functions",
+        "Native Go worker configuration",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Managed identity and optional VNet integration",
+        "VS Code debug configuration"
       ]
     },
     {
@@ -1583,6 +1611,35 @@
       ]
     },
     {
+      "id": "mcp-server-remote-go",
+      "displayName": "Remote MCP Server (Go + AZD + Bicep)",
+      "shortDescription": "Streamable HTTP MCP server with weather and Blob Storage snippet tools, deployed via azd",
+      "longDescription": "Build and deploy a remote MCP server on Azure Functions in Go. One HttpTrigger endpoint at /api/mcp hosts three tools using the official Model Context Protocol Go SDK: (1) get_weather calls the Open-Meteo API, (2) save_snippet writes text to Azure Blob Storage, and (3) get_snippet reads stored text. Runs on Flex Consumption with managed identity for Blob Storage access. Deployed with azd.",
+      "language": "Go",
+      "bindingType": "trigger",
+      "resource": "MCP",
+      "iac": "bicep",
+      "priority": 50,
+      "categories": [
+        "starters",
+        "gen-ai"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-mcp-go-azd",
+      "folderPath": ".",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Streamable HTTP MCP endpoint",
+        "Weather lookup MCP tool",
+        "Blob Storage save and retrieve snippet tools",
+        "Official Model Context Protocol Go SDK",
+        "Managed identity authentication",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "VS Code MCP configuration"
+      ]
+    },
+    {
       "id": "mcp-server-apim-python",
       "displayName": "Remote MCP Server with APIM Gateway (Python + AZD + Bicep)",
       "shortDescription": "MCP tools behind API Management gateway with Entra ID and OAuth, uses Blob storage",
@@ -2382,6 +2439,36 @@
         "HTTP endpoints",
         "requirements.txt",
         "README.md"
+      ]
+    },
+    {
+      "id": "agentframework-multi-agent-go",
+      "displayName": "Microsoft Agent Framework Multi-Agent (Go + AZD + Bicep)",
+      "shortDescription": "Single-agent chat and multi-agent NASA briefing with Azure OpenAI and Cosmos DB, deployed via azd",
+      "longDescription": "Build and deploy a Microsoft Agent Framework app on Azure Functions in Go with three HttpTrigger surfaces: (1) chat provides streaming single-agent conversations with NASA tools, (2) ui serves an embedded browser experience, and (3) brief_today runs an editor agent that calls four specialist agents as tools. Uses Azure OpenAI, Cosmos DB conversation persistence, managed identity, and five NASA API tools. Deployed with azd.",
+      "language": "Go",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 75,
+      "categories": [
+        "starters",
+        "gen-ai"
+      ],
+      "author": "Microsoft Agent Framework Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-msft-agent-framework-go-azd",
+      "folderPath": ".",
+      "gitRef": "refs/tags/v1.0.0",
+      "whatsIncluded": [
+        "Streaming single-agent chat endpoint",
+        "Multi-agent daily briefing endpoint",
+        "Embedded browser UI",
+        "Five NASA API tools",
+        "Azure OpenAI integration",
+        "Cosmos DB conversation persistence",
+        "Managed identity authentication",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration"
       ]
     },
     {

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -63,9 +63,9 @@
     "Go": {
       "supported": [],
       "preview": [
-        "1.24"
+        "1.0"
       ],
-      "default": "1.24"
+      "default": "1.0"
     }
   },
   "languages": [

--- a/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
+++ b/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
@@ -111,6 +111,7 @@
             "ARM",
             "Bicep",
             "CSharp",
+            "Go",
             "Java",
             "JavaScript",
             "PowerShell",


### PR DESCRIPTION
## Description

Adds Go HTTP, MCP, and Microsoft Agent Framework quickstarts to the template manifest. Enables Go in the schema, updates priority documentation, and pins each sample to its `v1.0.0` release.

## Checklist

- [x] Schema validation passes
- [x] Manifest references resolve
- [x] Priority tiers are consistent
