### PR TITLE
Update Dapr service templates

### DIFF
--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/.template.config/template.json
@@ -19,27 +19,6 @@
       "description": "namespace for the generated code",
       "replaces": "Company.Function",
       "type": "parameter"
-    },
-    "AccessRights": {
-      "type": "parameter",
-      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "Function",
-          "description": "Function"
-        },
-        {
-          "choice": "Anonymous",
-          "description": "Anonymous"
-        },
-        {
-          "choice": "Admin",
-          "description": "Admin"
-        }
-      ],
-      "replaces": "AuthLevelValue",
-      "defaultValue": "Function"
     }
   },
   "primaryOutputs": [
@@ -49,18 +28,6 @@
   ],
   "defaultName": "DaprServiceInvocationTriggerCSharp",
   "postActions": [
-    {
-      "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http Nuget package",
-      "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "ContinueOnError": "true",
-      "ManualInstructions": [],
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http",
-        "version": "3.3.0",
-        "projectFileExtensions": ".csproj"
-      }
-    },
     {
       "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Dapr Nuget package",
       "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/DaprServiceInvocationTriggerCSharp.cs
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp-Isolated/DaprServiceInvocationTriggerCSharp.cs
@@ -1,12 +1,8 @@
 namespace Company.Function
 {
-    using Microsoft.Azure.Functions.Extensions.Dapr.Core;
     using Microsoft.Azure.Functions.Worker;
     using Microsoft.Azure.Functions.Worker.Extensions.Dapr;
-    using Microsoft.Azure.Functions.Worker.Http;
     using Microsoft.Extensions.Logging;
-    using System.IO;
-    using System.Threading.Tasks;
 
     public static class DaprServiceInvocationTriggerCSharp
     {
@@ -37,31 +33,6 @@ namespace Company.Function
             var log = functionContext.GetLogger("DaprServiceInvocationTriggerCSharp");
             log.LogInformation("Azure function triggered by Dapr Service Invocation Trigger.");
             log.LogInformation($"Dapr service invocation trigger payload: {payload}");
-        }
-    }
-
-    public static class InvokeOutputBinding
-    {
-        /// <summary>
-        /// Sample to use a Dapr Invoke Output Binding to perform a Dapr Server Invocation operation hosted in another Darp'd app.
-        /// Here this function acts like a proxy
-        /// </summary>
-        [Function("InvokeOutputBinding")]
-        [DaprInvokeOutput(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")]
-        public static async Task<InvokeMethodParameters> Run(
-            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequestData req, FunctionContext functionContext)
-        {
-            var log = functionContext.GetLogger("InvokeOutputBinding");
-            log.LogInformation("C# HTTP trigger function processed a request.");
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-
-            var outputContent = new InvokeMethodParameters
-            {
-                Body = requestBody
-            };
-
-            return outputContent;
         }
     }
 }

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/.template.config/template.json
@@ -19,27 +19,6 @@
       "description": "namespace for the generated code",
       "replaces": "Company.Function",
       "type": "parameter"
-    },
-    "AccessRights": {
-      "type": "parameter",
-      "description": "Authorization level controls whether the function requires an API key and which key to use; Function uses a function key; Admin uses your master key. The function and master keys are found in the 'keys' management panel on the portal, when your function is selected.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "Function",
-          "description": "Function"
-        },
-        {
-          "choice": "Anonymous",
-          "description": "Anonymous"
-        },
-        {
-          "choice": "Admin",
-          "description": "Admin"
-        }
-      ],
-      "replaces": "AuthLevelValue",
-      "defaultValue": "Function"
     }
   },
   "primaryOutputs": [

--- a/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/DaprServiceInvocationTriggerCSharp.cs
+++ b/Functions.Templates/Templates/DaprServiceInvocationTrigger-CSharp/DaprServiceInvocationTriggerCSharp.cs
@@ -1,14 +1,8 @@
 namespace Company.Function
 {
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Azure.Functions.Extensions.Dapr.Core;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Dapr;
-    using Microsoft.Azure.WebJobs.Extensions.Http;
     using Microsoft.Extensions.Logging;
-    using System.IO;
-    using System.Threading.Tasks;
 
     public static class DaprServiceInvocationTriggerCSharp
     {
@@ -38,33 +32,6 @@ namespace Company.Function
         {
             log.LogInformation("Azure function triggered by Dapr Service Invocation Trigger.");
             log.LogInformation($"Dapr service invocation trigger payload: {payload}");
-        }
-    }
-
-    public static class InvokeOutputBinding
-    {
-        /// <summary>
-        /// Sample to use a Dapr Invoke Output Binding to perform a Dapr Server Invocation operation hosted in another Darp'd app.
-        /// Here this function acts like a proxy
-        /// </summary>
-        [FunctionName("InvokeOutputBinding")]
-        public static async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequest req,
-            [DaprInvoke(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")] IAsyncCollector<InvokeMethodParameters> output,
-            ILogger log)
-        {
-            log.LogInformation("C# HTTP trigger function processed a request.");
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-
-            var outputContent = new InvokeMethodParameters
-            {
-                Body = requestBody
-            };
-
-            await output.AddAsync(outputContent);
-
-            return new OkObjectResult("Successfully performed service invocation using Dapr invoke output binding.");
         }
     }
 }


### PR DESCRIPTION
## Description

Removed the HTTP-to-Dapr proxy from both C# templates:

• Isolated and in-process variants now contain only the Dapr trigger.
• Removed unused authorization options, imports, and isolated HTTP dependency.
• Eliminates arbitrary  appId  and  methodName 

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [ ] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [ ] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
