### PR TITLE
Rebrand ai-serverless-agents-python template to Azure Functions Hosted Skills

### DIFF
--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,7 +1,7 @@
 # Template Manifest — Priority Tiers (P00–P99)
 
 **Total templates:** 79
-**Manifest version:** 1.10.0
+**Manifest version:** 1.10.1
 
 ## Design principles
 

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-08-07T03:39:38Z",
+  "generatedAt": "2026-09-04T20:18:54Z",
   "version": "1.10.1",
   "totalTemplates": 79,
   "runtimeVersions": {
@@ -1773,9 +1773,9 @@
     },
     {
       "id": "ai-serverless-agents-python",
-      "displayName": "Azure Functions AI App QuickStart (Python + AZD + Bicep)",
-      "shortDescription": "Markdown-first Azure Functions AI app with a chat agent, a timer-triggered agent, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools, deployed via azd",
-      "longDescription": "Build and deploy an Azure Functions AI app in Python using the Azure Functions agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
+      "displayName": "Azure Functions Hosted Skills QuickStart (Python + AZD + Bicep)",
+      "shortDescription": "Markdown-first Azure Functions hosted skills with chat and timer triggers, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools, deployed via azd",
+      "longDescription": "Build and deploy Azure Functions hosted skills in Python using the Azure Functions agents runtime, a markdown-first programming model for building cloud-hosted, event-driven intelligent capabilities. Includes a chat hosted skill with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered hosted skill that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
       "language": "Python",
       "bindingType": "trigger",
       "resource": "http",
@@ -1787,8 +1787,7 @@
       ],
       "tags": [
         "AI",
-        "AI App",
-        "Agents",
+        "Hosted Skills",
         "Microsoft Foundry",
         "MCP",
         "AZD"
@@ -1798,8 +1797,8 @@
       "folderPath": ".",
       "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
-        "Chat agent defined in .agent.md with built-in debug chat UI and chat APIs",
-        "Timer-triggered Microsoft blog summary agent",
+        "Chat hosted skill defined in .agent.md with built-in debug chat UI and chat APIs",
+        "Timer-triggered Microsoft blog summary hosted skill",
         "Azure Functions agents runtime",
         "Sandboxed Python code execution using Azure Container Apps dynamic sessions",
         "Microsoft Foundry project and model deployment",

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-08-06T17:33:17Z",
-  "version": "1.10.0",
+  "generatedAt": "2026-08-07T03:39:38Z",
+  "version": "1.10.1",
   "totalTemplates": 79,
   "runtimeVersions": {
     "Python": {
@@ -1773,9 +1773,9 @@
     },
     {
       "id": "ai-serverless-agents-python",
-      "displayName": "Serverless Agents (Python + AZD + Bicep)",
-      "shortDescription": "Markdown-first serverless agents with chat, timer trigger, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools, deployed via azd",
-      "longDescription": "Build and deploy serverless agents on Azure Functions in Python using the Azure Functions serverless agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
+      "displayName": "Azure Functions AI App QuickStart (Python + AZD + Bicep)",
+      "shortDescription": "Markdown-first Azure Functions AI app with a chat agent, a timer-triggered agent, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools, deployed via azd",
+      "longDescription": "Build and deploy an Azure Functions AI app in Python using the Azure Functions agents runtime, a markdown-first programming model for building AI agents as function apps. Includes a chat agent with built-in debug chat UI, chat APIs, and MCP endpoint, plus a timer-triggered agent that gathers Microsoft blog posts, summarizes them, and can email the digest through MCP tools from a managed MCP server for a Microsoft 365 Outlook connector. Provisions a Flex Consumption function app, Microsoft Foundry project and model deployment, Azure Container Apps dynamic session pool, Connector Namespace resources when email delivery is enabled, managed identity, storage, and monitoring. Deployed with azd.",
       "language": "Python",
       "bindingType": "trigger",
       "resource": "http",
@@ -1787,8 +1787,8 @@
       ],
       "tags": [
         "AI",
+        "AI App",
         "Agents",
-        "Serverless",
         "Microsoft Foundry",
         "MCP",
         "AZD"
@@ -1800,7 +1800,7 @@
       "whatsIncluded": [
         "Chat agent defined in .agent.md with built-in debug chat UI and chat APIs",
         "Timer-triggered Microsoft blog summary agent",
-        "Azure Functions serverless agents runtime",
+        "Azure Functions agents runtime",
         "Sandboxed Python code execution using Azure Container Apps dynamic sessions",
         "Microsoft Foundry project and model deployment",
         "Optional Connector Namespace and managed MCP server for Microsoft 365 Outlook",


### PR DESCRIPTION
## Summary
Updates the user-visible branding of the `ai-serverless-agents-python` entry in the Template Manifest to **Azure Functions Hosted Skills**, aligned with the official product positioning and terminology. Machine-facing coordinates are preserved so downstream consumers keep working.

### User-visible changes (`Functions.Templates/Template-Manifest/manifest.json`)
- **displayName** → `Azure Functions Hosted Skills QuickStart (Python + AZD + Bicep)`
- **shortDescription** → describes Markdown-first hosted skills with chat and timer triggers, sandboxed Python execution, Microsoft Foundry, and Microsoft 365 Outlook connector tools
- **longDescription** → describes cloud-hosted, event-driven intelligent capabilities and refers to each `.agent.md` definition as a hosted skill
- **tags** → removes `Serverless`, `AI App`, and `Agents`; adds `Hosted Skills`
- **whatsIncluded** → renames the chat and timer agents to hosted skills
- Metadata: `version` 1.10.0 → 1.10.1 and `generatedAt` updated
- `docs/priority-tiers.md`: manifest version header synced to 1.10.1

### Preserved for compatibility
- `id`: `ai-serverless-agents-python`
- `repositoryUrl`: `https://github.com/Azure-Samples/functions-quickstart-serverless-agents-azd`
- `folderPath` (`.`), `gitRef` (`refs/tags/v1.0.0`)
- `language`, `bindingType`, `resource`, `iac`, `priority`, `categories`, `author`, and `isHighlighted`
- `Azure Functions agents runtime` package/product implementation name

Terminology follows [Azure Functions hosted skills](https://learn.microsoft.com/azure/azure-functions/functions-hosted-skills) and the corresponding `azure-functions-hosted-skills` rename in Azure/azure-functions-skills#218.

## Validation
- Manifest schema validation (`schemas/manifest.schema.json`): OK
- `totalTemplates`: 79, matching the template array length
- `shortDescription`: 181/200 characters
- `git diff --check`: clean