### PR TITLE
Update Durable Functions extension version to v3.15.0

### DIFF
--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1385,7 +1385,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1418,7 +1418,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1451,7 +1451,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\entityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1484,7 +1484,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1510,7 +1510,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -1385,7 +1385,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1418,7 +1418,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1451,7 +1451,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\entityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1484,7 +1484,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {
@@ -1510,7 +1510,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.15.0"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/.template.config/template.json
@@ -35,7 +35,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "3.3.1",
+        "version": "3.15.0",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
@@ -60,7 +60,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "3.3.1",
+        "version": "3.15.0",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
## Description

Updating Microsoft.Azure.WebJobs.Extensions.DurableTask references from 3.3.1 to 3.15.0.

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [ ] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [ ] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
