### PR TITLE
Add .NET 11 C# isolated template support with Azure.Functions.Sdk

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -44,6 +44,10 @@
                 "description": "Target .NET 10 (Preview)"
                 },
                 {
+                "choice": "net11.0",
+                "description": "Target .NET 11 (Preview)"
+                },
+                {
                 "choice": "net48",
                 "description": "Target .NET Framework 4.8"
                 }
@@ -55,7 +59,11 @@
         },
         "NetCore": {
             "type": "computed",
-            "value": "(Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net11.0\" || Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+        },
+        "Net11": {
+            "type": "computed",
+            "value": "(Framework == \"net11.0\")"
         },
         "FrameworkShouldUseV1Dependencies": {
             "type": "computed",
@@ -125,7 +133,7 @@
                         "value": "1.3.3"
                     },
                     {
-                        "value": "2.1.0"
+                        "value": "2.1.1"
                     }
                 ]
             }
@@ -143,6 +151,23 @@
                     },
                     {
                         "value": "2.0.7"
+                    }
+                ]
+            }
+        },
+        "ProjectSdkValue": {
+            "type": "generated",
+            "generator": "switch",
+            "replaces": "ProjectSdkValue",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "Net11",
+                        "value": "Azure.Functions.Sdk/1.0.1"
+                    },
+                    {
+                        "value": "Microsoft.NET.Sdk"
                     }
                 ]
             }

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -1,9 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="ProjectSdkValue">
 
   <PropertyGroup>
     <TargetFramework>TargetFrameworkValue</TargetFramework>
+<!--#if (!Net11)-->
     <AzureFunctionsVersion>AzureFunctionsVersionValue</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
+<!--#endif -->
 <!--#if (NetCore)-->
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -12,17 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-  <!--#if (NetCore)-->
+<!--#if (NetCore && !Net11)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  <!--#endif -->
+<!--#endif -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-  <!--#if (NetCore)-->
+<!--#if (NetCore)-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="FunctionsAspNetCorePackageVersionValue" />
-  <!--#endif -->
+<!--#endif -->
+<!--#if (!Net11)-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="FunctionsSdkPackageVersionValue" />
+<!--#endif -->
   </ItemGroup>
 
 </Project>

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -27,7 +27,7 @@
     },
     "NetCore": {
       "type": "computed",
-      "value": "(Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+      "value": "(Framework == \"net11.0\" || Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
     },
     "FrameworkShouldUseV1Dependencies": {
       "type": "computed",
@@ -93,7 +93,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
## Summary

- Add `net11.0` (Preview) to C# isolated project and HTTP item templates using `Azure.Functions.Sdk/1.0.1`.
- Explicitly reference Worker `2.52.0` per SDK guidance, keeping Worker/Grpc/Core aligned. Use HTTP ASP.NET Core extension `2.1.1`.
- Preserve OpenTelemetry behavior and the `net8.0` default. Existing F# templates are unchanged; F# .NET 11 support is deferred [pending legacy metadata generation in the new SDK](https://github.com/Azure/azure-functions-dotnet-worker/issues/3508). 

Relates to #1805.

## Validation

- Rebuilt template artifacts; C# .NET 10 and .NET 11 apps scaffold, build, publish, and return HTTP 200. Final local retest confirmed successful.

